### PR TITLE
Prepend chart name to kusto-credentials K8s secret name

### DIFF
--- a/charts/k2bridge/templates/deployment.yaml
+++ b/charts/k2bridge/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             - name: aadClientSecret
               valueFrom:
                 secretKeyRef:
-                  name: kusto-credentials
+                  name: {{ include "k2bridge.fullname" . }}-kusto-credentials
                   key: aadClientSecret
             - name: aadTenantId
               value: "{{ .Values.settings.aadTenantId }}"

--- a/charts/k2bridge/templates/secrets.yaml
+++ b/charts/k2bridge/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kusto-credentials
+  name: {{ include "k2bridge.fullname" . }}-kusto-credentials
 type: Opaque
 data:
   aadClientSecret: {{ .Values.settings.aadClientSecret  | b64enc | quote }}


### PR DESCRIPTION
The following changes are proposed:

* Fixed `kusto-credentials` K8s secret name, prepending the chart deployment name as for all other resources. This allows deploying multiple instances of the K2 chart in the same namespace.
