### PR TITLE
Fixing UTs on Windows

### DIFF
--- a/K2Bridge.Tests.UnitTests/JsonConverters/JsonConvertersExtensions.cs
+++ b/K2Bridge.Tests.UnitTests/JsonConverters/JsonConvertersExtensions.cs
@@ -30,6 +30,7 @@ namespace UnitTests.K2Bridge.JsonConverters
         private static string NormalizeChars(this string s) =>
             s.
             Replace(" ", string.Empty, StringComparison.OrdinalIgnoreCase).
+            Replace("\r", string.Empty, StringComparison.OrdinalIgnoreCase).
             Replace("\n", string.Empty, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
The following changes are proposed:

**Fix:**
* On Windows, JSON that is used for UTs assertion may contain \r. Removing them when comparing.

