### PR TITLE
Fixing backslashes escaping

### DIFF
--- a/K2Bridge.Tests.UnitTests/Visitors/LuceneNet/LuceneWildcardVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/LuceneNet/LuceneWildcardVisitorTests.cs
@@ -58,5 +58,27 @@ namespace UnitTests.K2Bridge.Visitors.LuceneNet
 
             return ((QueryStringClause)es).KustoQL;
         }
+
+        [TestCase(ExpectedResult = "* matches regex \"L\\\\o(.)*d(.)n\"")]
+        public string Visit_WithValidEscapedWildcardQuery_ReturnsValidResponse()
+        {
+            var wildcardQuery = new LuceneWildcardQuery
+            {
+                LuceneQuery =
+                new Lucene.Net.Search.WildcardQuery(
+                    new Lucene.Net.Index.Term("*", "L\\o*d?n")),
+            };
+
+            var luceneVisitor = new LuceneVisitor();
+            luceneVisitor.Visit(wildcardQuery);
+
+            var es = wildcardQuery.ESQuery;
+            Assert.NotNull(es);
+
+            var visitor = new ElasticSearchDSLVisitor(SchemaRetrieverMock.CreateMockSchemaRetriever());
+            visitor.Visit((QueryStringClause)es);
+
+            return ((QueryStringClause)es).KustoQL;
+        }
     }
 }

--- a/K2Bridge.Tests.UnitTests/Visitors/QueryStringClauseVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/QueryStringClauseVisitorTests.cs
@@ -67,7 +67,7 @@ namespace UnitTests.K2Bridge.Visitors
         }
 
         [TestCase(ExpectedResult =
-            "* has \"\\\"Get\"")]
+            "* has \"\\\\\"Get\"")]
         public string Visit_WithBreakQuotationPhrase_ReturnsAndContainsResponse()
         {
             var queryClause = CreateQueryStringClause("\\\"Get", false);
@@ -76,7 +76,7 @@ namespace UnitTests.K2Bridge.Visitors
         }
 
         [TestCase(ExpectedResult =
-            "* has \"\\dev\\kusto\\K2Bridge\"")]
+            "* has \"\\\\dev\\\\kusto\\\\K2Bridge\"")]
         public string Visit_WithBreakQuotePhrase_ReturnsAndContainsResponse()
         {
             var queryClause = CreateQueryStringClause(@"\dev\kusto\K2Bridge", false);

--- a/K2Bridge/Utils/StringExtensions.cs
+++ b/K2Bridge/Utils/StringExtensions.cs
@@ -11,8 +11,10 @@ namespace K2Bridge.Utils
     /// </summary>
     public static class StringExtensions
     {
-        public static string EscapeSlashes(this String str)
+        public static string EscapeSlashes(this string str)
         {
+            Ensure.IsNotNullOrEmpty(str, nameof(str), "Input cannot be null");
+
             return str.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/K2Bridge/Utils/StringExtensions.cs
+++ b/K2Bridge/Utils/StringExtensions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+namespace K2Bridge.Utils
+{
+    using System;
+
+    /// <summary>
+    /// String extensions methods
+    /// </summary>
+    public static class StringExtensions
+    {
+        public static string EscapeSlashes(this String str)
+        {
+            return str.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
+++ b/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
@@ -4,6 +4,7 @@
 
 namespace K2Bridge.Visitors
 {
+    using System;
     using System.Text.RegularExpressions;
     using K2Bridge.Models.Request.Queries;
 
@@ -25,7 +26,8 @@ namespace K2Bridge.Visitors
             // Must have a field name
             EnsureClause.StringIsNotNullOrEmpty(matchPhraseClause.FieldName, nameof(matchPhraseClause.FieldName));
 
-            matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{matchPhraseClause.Phrase}\"";
+            var escapedPhrase = matchPhraseClause.Phrase.Replace(@"\", @"\\\", StringComparison.OrdinalIgnoreCase);
+            matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{escapedPhrase}\"";
         }
     }
 }

--- a/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
+++ b/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
@@ -4,7 +4,6 @@
 
 namespace K2Bridge.Visitors
 {
-    using System;
     using System.Text.RegularExpressions;
     using K2Bridge.Models.Request.Queries;
     using K2Bridge.Utils;

--- a/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
+++ b/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
@@ -7,6 +7,7 @@ namespace K2Bridge.Visitors
     using System;
     using System.Text.RegularExpressions;
     using K2Bridge.Models.Request.Queries;
+    using K2Bridge.Utils;
 
     /// <content>
     /// A visitor for the <see cref="MatchPhraseClause"/> element.
@@ -28,8 +29,7 @@ namespace K2Bridge.Visitors
 
             if (matchPhraseClause.Phrase != null)
             {
-                var escapedPhrase = matchPhraseClause.Phrase.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
-                matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{escapedPhrase}\"";
+                matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{matchPhraseClause.Phrase.EscapeSlashes()}\"";
                 return;
             }
 

--- a/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
+++ b/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
@@ -28,7 +28,7 @@ namespace K2Bridge.Visitors
 
             if (matchPhraseClause.Phrase != null)
             {
-                var escapedPhrase = matchPhraseClause.Phrase.Replace(@"\", @"\\\", StringComparison.OrdinalIgnoreCase);
+                var escapedPhrase = matchPhraseClause.Phrase.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
                 matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{escapedPhrase}\"";
                 return;
             }

--- a/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
+++ b/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
@@ -26,8 +26,14 @@ namespace K2Bridge.Visitors
             // Must have a field name
             EnsureClause.StringIsNotNullOrEmpty(matchPhraseClause.FieldName, nameof(matchPhraseClause.FieldName));
 
-            var escapedPhrase = matchPhraseClause.Phrase.Replace(@"\", @"\\\", StringComparison.OrdinalIgnoreCase);
-            matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{escapedPhrase}\"";
+            if (matchPhraseClause.Phrase != null)
+            {
+                var escapedPhrase = matchPhraseClause.Phrase.Replace(@"\", @"\\\", StringComparison.OrdinalIgnoreCase);
+                matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{escapedPhrase}\"";
+                return;
+            }
+
+            matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"\"";
         }
     }
 }

--- a/K2Bridge/Visitors/QueryStringClauseVisitor.cs
+++ b/K2Bridge/Visitors/QueryStringClauseVisitor.cs
@@ -40,6 +40,8 @@ namespace K2Bridge.Visitors
                 return;
             }
 
+            var escapedPhrase = queryStringClause.Phrase.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
+
             // Depends on the exact request there are 3 possible options for the phrase:
             // wildcard, prefix and simple equality
             switch (queryStringClause.ParsedType)
@@ -60,14 +62,12 @@ namespace K2Bridge.Visitors
                     }
                     else
                     {
-                        var escaped = queryStringClause.Phrase.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
-                        queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Has} \"{escaped}\"";
+                        queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Has} \"{escapedPhrase}\"";
                     }
 
                     break;
 
                 case QueryStringClause.Subtype.Phrase:
-                    var escapedPhrase = queryStringClause.Phrase.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
                     queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Contains} \"{escapedPhrase}\"";
                     break;
 
@@ -77,13 +77,13 @@ namespace K2Bridge.Visitors
                     // to be consistent with the way ES works
                     // for example consider the following queries:
                     // TelA* => TelA[.\S]*
-                    var phrase = SingleCharPattern.Replace(queryStringClause.Phrase, @"(.)");
+                    var phrase = SingleCharPattern.Replace(escapedPhrase, @"(.)");
                     phrase = MultiCharPattern.Replace(phrase, @"(.)*");
 
                     queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.MatchRegex} \"{phrase}\"";
                     break;
                 case QueryStringClause.Subtype.Prefix:
-                    queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.HasPrefix} \"{queryStringClause.Phrase}\"";
+                    queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.HasPrefix} \"{escapedPhrase}\"";
                     break;
                 default:
                     // should not happen

--- a/K2Bridge/Visitors/QueryStringClauseVisitor.cs
+++ b/K2Bridge/Visitors/QueryStringClauseVisitor.cs
@@ -60,13 +60,15 @@ namespace K2Bridge.Visitors
                     }
                     else
                     {
-                        queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Has} \"{queryStringClause.Phrase}\"";
+                        var escaped = queryStringClause.Phrase.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
+                        queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Has} \"{escaped}\"";
                     }
 
                     break;
 
                 case QueryStringClause.Subtype.Phrase:
-                    queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Contains} \"{queryStringClause.Phrase}\"";
+                    var escapedPhrase = queryStringClause.Phrase.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
+                    queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Contains} \"{escapedPhrase}\"";
                     break;
 
                 case QueryStringClause.Subtype.Wildcard:


### PR DESCRIPTION
The following changes are proposed:

Escaping backslashes both for query string clause and match phrase clause.
Fixed relevant UTs
Added another UT
