### PR TITLE
Add dynamic columns filtering, fix doublequotes escaping.

### DIFF
--- a/K2Bridge/KustoDAL/KustoDataAccess.cs
+++ b/K2Bridge/KustoDAL/KustoDataAccess.cs
@@ -142,11 +142,10 @@ namespace K2Bridge.KustoDAL
                     string dynamicQuery = $"{tableName} | {KustoQLOperators.Where} ingestion_time() > ago({MaxFieldCapsLookbackTime}) | {KustoQLOperators.Where} isnotempty({fieldCapabilityElement.Name}) | {KustoQLOperators.Sample} {MaxFieldCapsSampleSize} | {KustoQLOperators.Project} {MaxFieldCapsUniqueGetSchemaColumn}={fieldCapabilityElement.Name} | {KustoQLOperators.Evaluate} bag_unpack({MaxFieldCapsUniqueGetSchemaColumn}) | {KustoQLOperators.GetSchema} | {KustoQLOperators.Project} ColumnName=strcat('{fieldCapabilityElement.Name}','.',ColumnName),ColumnType=DataType";
 
                     var dynamicQueryData = new QueryData(dynamicQuery, tableName, null, null);
-                    TimeSpan timeTaken;
                     IDataReader reader;
                     try
                     {
-                        (timeTaken, reader) = await Kusto.ExecuteQueryAsync(dynamicQueryData, RequestContext);
+                        (_, reader) = await Kusto.ExecuteQueryAsync(dynamicQueryData, RequestContext);
                     }
                     catch (K2Bridge.KustoDAL.QueryException)
                     {

--- a/K2Bridge/KustoDAL/KustoDataAccess.cs
+++ b/K2Bridge/KustoDAL/KustoDataAccess.cs
@@ -142,7 +142,16 @@ namespace K2Bridge.KustoDAL
                     string dynamicQuery = $"{tableName} | {KustoQLOperators.Where} ingestion_time() > ago({MaxFieldCapsLookbackTime}) | {KustoQLOperators.Where} isnotempty({fieldCapabilityElement.Name}) | {KustoQLOperators.Sample} {MaxFieldCapsSampleSize} | {KustoQLOperators.Project} {MaxFieldCapsUniqueGetSchemaColumn}={fieldCapabilityElement.Name} | {KustoQLOperators.Evaluate} bag_unpack({MaxFieldCapsUniqueGetSchemaColumn}) | {KustoQLOperators.GetSchema} | {KustoQLOperators.Project} ColumnName=strcat('{fieldCapabilityElement.Name}','.',ColumnName),ColumnType=DataType";
 
                     var dynamicQueryData = new QueryData(dynamicQuery, tableName, null, null);
-                    var (timeTaken, reader) = await Kusto.ExecuteQueryAsync(dynamicQueryData, RequestContext);
+                    TimeSpan timeTaken;
+                    IDataReader reader;
+                    try
+                    {
+                        (timeTaken, reader) = await Kusto.ExecuteQueryAsync(dynamicQueryData, RequestContext);
+                    }
+                    catch (K2Bridge.KustoDAL.QueryException)
+                    {
+                        continue;
+                    }
 
                     await MapFieldCapsAsync(reader, response, tableName, depth + 1);
                 }

--- a/K2Bridge/Utils/StringExtensions.cs
+++ b/K2Bridge/Utils/StringExtensions.cs
@@ -17,5 +17,12 @@ namespace K2Bridge.Utils
 
             return str.Replace(@"\", @"\\", StringComparison.OrdinalIgnoreCase);
         }
+
+        public static string EscapeDoublequotes(this string str)
+        {
+            Ensure.IsNotNullOrEmpty(str, nameof(str), "Input cannot be null");
+
+            return str.Replace(@"""", @"\""", StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/K2Bridge/Visitors/KustoQLOperators.cs
+++ b/K2Bridge/Visitors/KustoQLOperators.cs
@@ -46,6 +46,8 @@ namespace K2Bridge.Visitors
         public const string HasPrefix = "hasprefix";
         public const string MatchRegex = "matches regex";
         public const string GetSchema = "getschema";
+        public const string Evaluate = "evaluate";
+        public const string Sample = "sample";
         public const string Equal = "==";
         public const string CommandSeparator = "\n| ";
 #pragma warning restore SA1600 // Elements should be documented

--- a/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
+++ b/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
@@ -28,7 +28,7 @@ namespace K2Bridge.Visitors
 
             if (matchPhraseClause.Phrase != null)
             {
-                matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{matchPhraseClause.Phrase.EscapeSlashes()}\"";
+                matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"{matchPhraseClause.Phrase.EscapeSlashes().EscapeDoublequotes()}\"";
                 return;
             }
 

--- a/K2Bridge/Visitors/QueryStringClauseVisitor.cs
+++ b/K2Bridge/Visitors/QueryStringClauseVisitor.cs
@@ -67,7 +67,7 @@ namespace K2Bridge.Visitors
                     break;
 
                 case QueryStringClause.Subtype.Phrase:
-                    queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Contains} \"{queryStringClause.Phrase.EscapeSlashes()}\"";
+                    queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.Contains} \"{queryStringClause.Phrase}\"";
                     break;
 
                 case QueryStringClause.Subtype.Wildcard:


### PR DESCRIPTION
Fixes #2 and #26.
This solves the problem of filtering the nested JSON/dynamic fields for us.

**The logic behind this**
While getting FieldCapabilities if the table or function has a column with type "System.Object", we recursively perform `getschema` on 8 sampled rows of these columns(including nested ones). We add every possible `dynamic` property to the FieldCapabilities response, nesting them under main columns. The samples are bounded by 4h of lookback time, property depth is limited at 4.
I.e. we have such document in a column named `JSON`:

```json
{
	"Payload": {
		"eventId": {
			"Id": 108,
			"Name": "GeneratedHeaderUsingProvider"
		}
	}
}
```

When you try to get FieldCapabilities on index with this document in dynamic field, the code will look into 8 samples of this column JSON, `bag_unpack | getschema` will return that it has a sub-property `Payload`. Then it will recursively look into `JSON.Payload.eventId`, which in turn will have two columns with types int and string.

Kusto query that finds the properties looks like this:

```KQL
JSON 
| where ingestion_time() > ago(4h) 
| where isnotempty(Payload.eventId) 
| sample 16 
| project K2BridgeGetSchemaColumn=Payload.eventId  
| evaluate bag_unpack(K2BridgeGetSchemaColumn) 
| getschema 
| project ColumnName = strcat('Payload.eventId','.',ColumnName),ColumnType = DataType
```

We would get these fields added as FieldCaps to Kibana index mapping and the filter will work:

```
JSON.Payload.eventId.Id int
JSON.Payload.EventId.Name string
```


**Why `try-catch` while getting fields from Kusto?** 
https://github.com/dodopizza/K2Bridge/blob/e75b6986a94a7844b9c090f0550203d7bb8744a5/K2Bridge/KustoDAL/KustoDataAccess.cs#L146

We found out that some of our logs have "*" as property name.

For example, K2Bridge logs such jsons:

```json
{
	"SourceContext": "K2Bridge.KustoDAL.KustoQueryExecutor",
	"queryData": {
		"Data": {
			"$type": "QueryData",
			"QueryCommandText": "REDACTED",
			"HighlightPostTag": "@/kibana-highlighted-field@",
			"HighlightPreTag": "@kibana-highlighted-field@",
			"IndexName": "REDACTED",
			"DocValueFields": [
				"Timestamp"
			],
			"HighlightText": {
				"Cluster": "dev",
				"*": "App:(\"REDACTED\", \"REDACTED\", \"REDACTED\", \"REDACTED\")"
			},
			"SortFields": [
				"Timestamp"
			]
		}
	}
}
```

As you can see here, we have a property `*` under `queryData.Data.HighlightText`. When `bag_unpack` tries to unpack it into a column, it fails. We have to somehow tell bag_unpack not to unpack this into column, but I had a hard time filtering property with such name, it seems that  only `mv-apply` will work...

We also fixed doublequotes escape(#26) because now the filtering works this is a much bigger problem.


We understand that this is a very, very suboptimal and a hacky way to implement this, and are looking for a feedback and ways to improve this. Our approach utilizes sampling, so not 100% of properties get sampled and we do not discover 100% nested properties.