### PR TITLE
Reorder Query Filters per Operator Set

### DIFF
--- a/K2Bridge.Tests.UnitTests/Visitors/QueryStringClauseVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/QueryStringClauseVisitorTests.cs
@@ -4,52 +4,46 @@
 
 namespace UnitTests.K2Bridge.Visitors
 {
-    using global::K2Bridge.Models.Request;
     using global::K2Bridge.Models.Request.Queries;
     using global::K2Bridge.Tests.UnitTests.Visitors;
-    using global::K2Bridge.Visitors;
     using NUnit.Framework;
 
     [TestFixture]
     public class QueryStringClauseVisitorTests
     {
-        [TestCase(ExpectedResult = "* has \"myPharse\"")]
+        [TestCase(ExpectedResult = "* has \"myPhrase\"")]
         public string Visit_WithSimplePhrase_ReturnsHasResponse()
         {
-            var queryClause = CreateQueryStringClause("myPharse", true);
+            var queryClause = CreateQueryStringClause("myPhrase", true);
 
             return VisitQuery(queryClause);
         }
 
-        [TestCase(ExpectedResult =
-            "(* has \"myPharse\") and (* has \"herPhrase\")")]
+        [TestCase(ExpectedResult = "(* has \"myPhrase\") and (* has \"herPhrase\")")]
         public string Visit_WithMultiplePhrase_ReturnsHasAndResponse()
         {
-            var queryClause = CreateQueryStringClause("myPharse AND herPhrase", true);
+            var queryClause = CreateQueryStringClause("myPhrase AND herPhrase", true);
 
             return VisitQuery(queryClause);
         }
 
-        [TestCase(ExpectedResult =
-            "(* has \"myPharse\") or (* has \"herPhrase\")")]
+        [TestCase(ExpectedResult = "(* has \"myPhrase\") or (* has \"herPhrase\")")]
         public string Visit_WithMultipleOrPhrase_ReturnsHasOrResponse()
         {
-            var queryClause = CreateQueryStringClause("myPharse OR herPhrase", true);
+            var queryClause = CreateQueryStringClause("myPhrase OR herPhrase", true);
 
             return VisitQuery(queryClause);
         }
 
-        [TestCase(ExpectedResult =
-            "(* !has \"myPharse\") and (* !has \"herPhrase\")")]
+        [TestCase(ExpectedResult = "(* !has \"myPhrase\") and (* !has \"herPhrase\")")]
         public string Visit_WithMultipleNotPhrase_ReturnsHasAndNotResponse()
         {
-            var queryClause = CreateQueryStringClause("NOT myPharse AND NOT herPhrase", true);
+            var queryClause = CreateQueryStringClause("NOT myPhrase AND NOT herPhrase", true);
 
             return VisitQuery(queryClause);
         }
 
-        [TestCase(ExpectedResult =
-            "(* has \"Dogs\") and (* contains \"My cats\")")]
+        [TestCase(ExpectedResult = "(* has \"Dogs\") and (* contains \"My cats\")")]
         public string Visit_WithQuotationPhrase_ReturnsContainsResponse()
         {
             var queryClause = CreateQueryStringClause("Dogs AND \"My cats\"", true);
@@ -57,8 +51,15 @@ namespace UnitTests.K2Bridge.Visitors
             return VisitQuery(queryClause);
         }
 
-        [TestCase(ExpectedResult =
-            "(* has \"Tokyo\") and (* contains \"Haneda International\") or ((* has \"A\") and (* contains \"b c\"))")]
+        [TestCase(ExpectedResult = "(* has \"shouldBeFirst\") and (* has \"shouldBeSecond\") and (this.that has \"shouldBeThird\") and (that.this contains \"should be fourth\")")]
+        public string Visit_WithDynamicFields_ReturnsSortedResponse()
+        {
+            var queryClause = CreateQueryStringClause("this.that:shouldBeThird AND shouldBeFirst AND that.this:\"should be fourth\" AND shouldBeSecond", true);
+
+            return VisitQuery(queryClause);
+        }
+
+        [TestCase(ExpectedResult = "(* has \"Tokyo\") and (* contains \"Haneda International\") or ((* has \"A\") and (* contains \"b c\"))")]
         public string Visit_WithMultipleQuotationPhrase_ReturnsAndContainsResponse()
         {
             var queryClause = CreateQueryStringClause("Tokyo AND \"Haneda International\" OR (A AND \"b c\")", true);
@@ -66,8 +67,7 @@ namespace UnitTests.K2Bridge.Visitors
             return VisitQuery(queryClause);
         }
 
-        [TestCase(ExpectedResult =
-            "* has \"\\\\\"Get\"")]
+        [TestCase(ExpectedResult = "* has \"\\\\\"Get\"")]
         public string Visit_WithBreakQuotationPhrase_ReturnsAndContainsResponse()
         {
             var queryClause = CreateQueryStringClause("\\\"Get", false);
@@ -75,8 +75,7 @@ namespace UnitTests.K2Bridge.Visitors
             return VisitQuery(queryClause);
         }
 
-        [TestCase(ExpectedResult =
-            "* has \"\\\\dev\\\\kusto\\\\K2Bridge\"")]
+        [TestCase(ExpectedResult = "* has \"\\\\dev\\\\kusto\\\\K2Bridge\"")]
         public string Visit_WithBreakQuotePhrase_ReturnsAndContainsResponse()
         {
             var queryClause = CreateQueryStringClause(@"\dev\kusto\K2Bridge", false);

--- a/K2Bridge/KustoDAL/KustoQueryExecutor.cs
+++ b/K2Bridge/KustoDAL/KustoQueryExecutor.cs
@@ -45,7 +45,8 @@ namespace K2Bridge.KustoDAL
             this.metricsHistograms = metricsHistograms;
         }
 
-        public string DefaultDatabaseName { get => queryClient.DefaultDatabaseName; }
+        /// <inheritdoc/>
+        public string DefaultDatabaseName => queryClient.DefaultDatabaseName;
 
         private ILogger Logger { get; set; }
 

--- a/K2Bridge/Models/Request/Queries/QueryStringClause.cs
+++ b/K2Bridge/Models/Request/Queries/QueryStringClause.cs
@@ -21,12 +21,12 @@ namespace K2Bridge.Models.Request.Queries
         public enum Subtype
         {
             /// <summary>
-            /// A pharse which is a word (no tokens inside).
+            /// A phrase which is a word (no tokens inside).
             /// </summary>
             Term = 0,
 
             /// <summary>
-            /// A pharse which can be multiple terms (a sentance with spaces).
+            /// A phrase which can be multiple terms (a sentence with spaces).
             /// </summary>
             Phrase,
 

--- a/K2Bridge/Visitors/BoolClauseVisitor.cs
+++ b/K2Bridge/Visitors/BoolClauseVisitor.cs
@@ -31,7 +31,10 @@ namespace K2Bridge.Visitors
             AddListInternal(boolQuery.Should, KustoQLOperators.Or, false /* positive */, kustoQuery);
             AddListInternal(boolQuery.ShouldNot, KustoQLOperators.Or, true /* negative */, kustoQuery);
 
-            boolQuery.KustoQL = kustoQuery.ToString();
+            if (kustoQuery.Length > 0 && (boolQuery.KustoQL == null || kustoQuery.Length > boolQuery.KustoQL.Length))
+            {
+                boolQuery.KustoQL = kustoQuery.ToString();
+            }
         }
 
         /// <summary>

--- a/K2Bridge/Visitors/BoolClauseVisitor.cs
+++ b/K2Bridge/Visitors/BoolClauseVisitor.cs
@@ -50,6 +50,8 @@ namespace K2Bridge.Visitors
                 kustoQuery.Append($"{paddedJoinString}");
             }
 
+            // Group2 will be matched if a period character '.' is found in field name, meaning the filter is on a dynamic column.
+            // OrderBy will sort the list such that non-dynamic filters will be followed by dynamic ones, which improves Kusto query performance.
             var orderedList = queryList.OrderBy(exp => DynamicRegex.Match(exp).Groups[2].Success);
 
             kustoQuery.Append($"{string.Join(paddedJoinString, orderedList)}");

--- a/K2Bridge/Visitors/BoolClauseVisitor.cs
+++ b/K2Bridge/Visitors/BoolClauseVisitor.cs
@@ -5,6 +5,8 @@
 namespace K2Bridge.Visitors
 {
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
     using System.Text.RegularExpressions;
     using K2Bridge.Models.Request;
     using K2Bridge.Models.Request.Queries;
@@ -15,44 +17,45 @@ namespace K2Bridge.Visitors
     internal partial class ElasticSearchDSLVisitor : IVisitor
     {
         private static readonly Regex OperatorsRegex = new Regex($"^[^ ]+ ({KustoQLOperators.Has}|{KustoQLOperators.Contains}|{KustoQLOperators.HasPrefix})|({KustoQLOperators.Equal})");
+        private static readonly Regex DynamicRegex = new Regex("^((\\.)|[^ !=])+");
 
         /// <inheritdoc/>
         public void Visit(BoolQuery boolQuery)
         {
             Ensure.IsNotNull(boolQuery, nameof(boolQuery));
+            var kustoQuery = new StringBuilder(boolQuery.KustoQL);
 
-            AddListInternal(boolQuery.Filter, KustoQLOperators.And, false /* positive */, boolQuery);
-            AddListInternal(boolQuery.Must, KustoQLOperators.And, false /* positive */, boolQuery);
-            AddListInternal(boolQuery.MustNot, KustoQLOperators.And, true /* negative */, boolQuery);
-            AddListInternal(boolQuery.Should, KustoQLOperators.Or, false /* positive */, boolQuery);
-            AddListInternal(boolQuery.ShouldNot, KustoQLOperators.Or, true /* negative */, boolQuery);
+            AddListInternal(boolQuery.Filter, KustoQLOperators.And, false /* positive */, kustoQuery);
+            AddListInternal(boolQuery.Must, KustoQLOperators.And, false /* positive */, kustoQuery);
+            AddListInternal(boolQuery.MustNot, KustoQLOperators.And, true /* negative */, kustoQuery);
+            AddListInternal(boolQuery.Should, KustoQLOperators.Or, false /* positive */, kustoQuery);
+            AddListInternal(boolQuery.ShouldNot, KustoQLOperators.Or, true /* negative */, kustoQuery);
+
+            boolQuery.KustoQL = kustoQuery.ToString();
         }
 
         /// <summary>
-        /// Joins the list of KustoQL commands and modifies the given BoolQuery.
+        /// Joins the list of KustoQL commands and modifies the given StringBuilder.
         /// </summary>
-        private static void QueryListToString(List<string> queryList, string joinString, BoolQuery boolQuery)
+        private static void QueryListToString(ICollection<string> queryList, string joinString, StringBuilder kustoQuery)
         {
-            joinString = $" {joinString} ";
+            var paddedJoinString = $" {joinString} ";
 
-            if (queryList?.Count > 0)
+            // In case we already have something in KustoQL, we need to first add a separator
+            if (kustoQuery.Length > 0)
             {
-                // In case we already have something in KustoQL, we need to first
-                // add a separator
-                if (!string.IsNullOrEmpty(boolQuery.KustoQL))
-                {
-                    boolQuery.KustoQL += $"{joinString}";
-                }
-
-                // Now, join the given list separated with the given word
-                boolQuery.KustoQL += $"{string.Join(joinString, queryList)}";
+                kustoQuery.Append($"{paddedJoinString}");
             }
+
+            var orderedList = queryList.OrderBy(exp => DynamicRegex.Match(exp).Groups[2].Success);
+
+            kustoQuery.Append($"{string.Join(paddedJoinString, orderedList)}");
         }
 
         /// <summary>
         /// Create a list of clauses of a specific type (must / must not / should / should not).
         /// </summary>
-        private void AddListInternal(IEnumerable<IQuery> list, string delimiterKeyword, bool negateCondition, BoolQuery boolQuery)
+        private void AddListInternal(IEnumerable<IQuery> list, string delimiterKeyword, bool negateCondition, StringBuilder kustoQuery)
         {
             if (list == null)
             {
@@ -98,7 +101,10 @@ namespace K2Bridge.Visitors
                 }
             }
 
-            QueryListToString(kqlExpressions, delimiterKeyword, boolQuery);
+            if (kqlExpressions.Count > 0)
+            {
+                QueryListToString(kqlExpressions, delimiterKeyword, kustoQuery);
+            }
         }
     }
 }


### PR DESCRIPTION
The following changes are proposed:

* Query filters which are on dynamic columns will be pushed to the end of the Operator set, which will improve query performance.
* In a future PR, this will be done on a query level instead on a parameter-set level.
