### PR TITLE
feat: Update development container with elastic stack 7.10 version 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,7 +33,7 @@ RUN dpkg -i packages-microsoft-prod.deb
 RUN rm packages-microsoft-prod.deb
 
 RUN apt-get update && \
-    apt-get install -y dotnet-sdk-3.1 dotnet-sdk-5.0
+    apt-get install -y dotnet-sdk-5.0 dotnet-sdk-6.0
 
 # Set current working directory to /home/vscode
 USER vscode

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,14 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-ubuntu20.04
 
-ARG BUILD_ELASTIC_STACK_VERSION="6.8.20"
+ARG BUILD_ELASTIC_STACK_VERSION="7.10.2"
 ARG BUILD_TERRAFORM_VERSION="1.0.9"
+ARG BUILD_MITMPROXY_VERSION="7.0.4"
 
 # Update & Install Open JDK
 RUN apt-get update && apt-get upgrade -y && apt-get install -y default-jre
 
 # Install Terraform
 ENV TERRAFORM_VERSION=${BUILD_TERRAFORM_VERSION}
-
 RUN curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip -o terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin
 RUN rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
@@ -20,6 +20,12 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 RUN chmod 700 get_helm.sh
 RUN ./get_helm.sh
+
+# Install mitmproxy
+ENV MITMPROXY_VERSION=${BUILD_MITMPROXY_VERSION}
+RUN wget https://snapshots.mitmproxy.org/${MITMPROXY_VERSION}/mitmproxy-${MITMPROXY_VERSION}-linux.tar.gz
+RUN tar -xzf mitmproxy-${MITMPROXY_VERSION}-linux.tar.gz -C /usr/local/bin
+RUN rm mitmproxy-${MITMPROXY_VERSION}-linux.tar.gz
 
 # Install .NET SDK
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
@@ -37,12 +43,12 @@ WORKDIR $HOME
 # Install ElasticSearch
 ENV ELASTIC_STACK_VERSION=${BUILD_ELASTIC_STACK_VERSION}
 
-RUN wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ELASTIC_STACK_VERSION}.tar.gz
-RUN wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ELASTIC_STACK_VERSION}.tar.gz.sha512
-RUN shasum -a 512 -c elasticsearch-oss-${ELASTIC_STACK_VERSION}.tar.gz.sha512
-RUN tar -xzf elasticsearch-oss-${ELASTIC_STACK_VERSION}.tar.gz
-RUN rm elasticsearch-oss-${ELASTIC_STACK_VERSION}.tar.gz
-RUN rm elasticsearch-oss-${ELASTIC_STACK_VERSION}.tar.gz.sha512
+RUN wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ELASTIC_STACK_VERSION}-linux-x86_64.tar.gz
+RUN wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-${ELASTIC_STACK_VERSION}-linux-x86_64.tar.gz.sha512
+RUN shasum -a 512 -c elasticsearch-oss-${ELASTIC_STACK_VERSION}-linux-x86_64.tar.gz.sha512
+RUN tar -xzf elasticsearch-oss-${ELASTIC_STACK_VERSION}-linux-x86_64.tar.gz
+RUN rm elasticsearch-oss-${ELASTIC_STACK_VERSION}-linux-x86_64.tar.gz
+RUN rm elasticsearch-oss-${ELASTIC_STACK_VERSION}-linux-x86_64.tar.gz.sha512
 
 # Install Kibana
 RUN wget https://artifacts.elastic.co/downloads/kibana/kibana-oss-${ELASTIC_STACK_VERSION}-linux-x86_64.tar.gz

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
     "build": {
         "dockerfile": "Dockerfile",
     },
+    "mounts": [
+        "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind"
+    ],
     "extensions": [
         "hashicorp.terraform",
         "ms-vscode.azurecli",

--- a/docs/devcontainer-mitmproxy.md
+++ b/docs/devcontainer-mitmproxy.md
@@ -1,0 +1,110 @@
+# Intercept requests using mitmproxy
+
+If you need to intercept http requests between Kibana <---> K2Bridge, the development container provides [mitmproxy](https://mitmproxy.org/) tools. mitmproxy is a free and open source interactive HTTPS proxy.
+
+## Steps to configure and run mitmproxy
+
+### 1. Start Elastic Search
+
+```bash
+vscode ➜ /workspaces/K2Bridge/.devcontainer (feature/devcontainer-7.10 ✗) $ cd $home
+vscode ➜ ~ $ cd elasticsearch-7.10.2/
+vscode ➜ ~/elasticsearch-7.10.2 $ ./bin/elasticsearch
+
+[...]
+[2021-11-10T10:29:41,395][INFO ][o.e.h.AbstractHttpServerTransport] [9f911f701eba] publish_address {127.0.0.1:9200}, bound_addresses {127.0.0.1:9200}
+[2021-11-10T10:29:41,397][INFO ][o.e.n.Node               ] [9f911f701eba] started
+[2021-11-10T10:29:41,444][INFO ][o.e.g.GatewayService     ] [9f911f701eba] recovered [0] indices into cluster_state
+```
+
+Open a web browser and target http://localhost:9200/. Similar json must be returned.
+
+```json
+{
+  "name" : "9f911f701eba",
+  "cluster_name" : "elasticsearch",
+  "cluster_uuid" : "IfhhAPkOT8m_zfIkUfHtWg",
+  "version" : {
+    "number" : "7.10.2",
+    "build_flavor" : "oss",
+    "build_type" : "tar",
+    "build_hash" : "747e1cc71def077253878a59143c1f785afa92b9",
+    "build_date" : "2021-01-13T00:42:12.435326Z",
+    "build_snapshot" : false,
+    "lucene_version" : "8.7.0",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
+  },
+  "tagline" : "You Know, for Search"
+}
+```
+
+### 2. Start K2Bridge
+
+Start K2Bridge with appropriate settings (as explained in [development](./development.md) section). 
+However, in appsettings.Development.json, please change the default K2Bridge listener port (for instance 8081). Do not use 8080, it will be preempted by mitmproxy.
+
+``` json
+[...]
+"bridgeListenerAddress": "http://localhost:8081",
+[...]
+```
+
+Open a web browser and target http://localhost:8081/. Similar json must be returned.
+
+```json
+{
+  "name" : "Aj2lFRl",
+  "cluster_name" : "elasticsearch",
+  "cluster_uuid" : "RqGRp20aRlO2b7DTkPjmDg",
+  "version" : {
+    "number" : "6.8.20",
+    "build_flavor" : "oss",
+    "build_type" : "tar",
+    "build_hash" : "c859302",
+    "build_date" : "2021-10-07T22:00:24.085009Z",
+    "build_snapshot" : false,
+    "lucene_version" : "7.7.3",
+    "minimum_wire_compatibility_version" : "5.6.0",
+    "minimum_index_compatibility_version" : "5.0.0"
+  },
+  "tagline" : "You Know, for Search"
+}
+```
+
+### 3. Start mitmweb 
+
+mitmweb is a web-based interface for mitmproxy. The reverse proxy mode will intercept requests on 8080 port and redirect them to K2Bridge (running on 8081). 
+
+```bash
+vscode ➜ /workspaces/K2Bridge (feature/devcontainer-7.10 ✗) $ mitmweb --web-port 8888 --mode reverse:http://localhost:8081
+Web server listening at http://127.0.0.1:8888/
+Proxy server listening at http://*:8080
+```
+
+Open a web browser and target http://localhost:8888/ to access the mitmproxy Web UI.
+
+### 4.Start Kibana
+
+Under Kibana's '*config*' directory, edit the *kibana.yml* file and add the following line. Note that this assumes that mitmproxy will listen on port 8080.
+
+```bash
+vscode ➜ /workspaces/K2Bridge (feature/devcontainer-7.10) $ cd $home
+vscode ➜ ~ $ cd kibana-7.10.2-linux-x86_64/
+vscode ➜ ~/kibana-7.10.2-linux-x86_64 $ code ./config/kibana.yml
+```
+```yaml
+# The URLs of the Elasticsearch instances to use for all your queries.
+elasticsearch.hosts: ["http://localhost:8080"]
+```
+
+Then start Kibana.
+```bash
+vscode ➜ ~/kibana-7.10.2-linux-x86_64 $ ./bin/kibana
+[...]
+  log   [10:32:18.179] [info][plugins-system] Starting [40] plugins: [usageCollection,telemetryCollectionManager,telemetry,kibanaUsageCollection,securityOss,newsfeed,mapsLegacy,kibanaLegacy,share,legacyExport,embeddable,expressions,data,home,console,apmOss,management,indexPatternManagement,advancedSettings,savedObjects,dashboard,visualizations,inputControlVis,visTypeVega,visTypeTimelion,timelion,visTypeTable,visTypeMarkdown,tileMap,regionMap,visualize,esUiShared,charts,visTypeTimeseries,visTypeVislib,visTypeTagcloud,visTypeMetric,discover,savedObjectsManagement,bfetch]
+  log   [10:32:18.793] [info][listening] Server running at http://localhost:5601
+  log   [10:32:18.851] [info][server][Kibana][http] http server running at http://localhost:5601
+```
+
+Open a web browser and target http://localhost:5601/ to access the Kibana UI.

--- a/docs/devcontainer-quickstart.md
+++ b/docs/devcontainer-quickstart.md
@@ -15,7 +15,7 @@ The following packages are installed on top of this base image.
 | azure-cli | latest |
 | helm | latest |
 | mitmproxy | 7.0.4 |
-| dotnet-sdk-3.1 | latest |
+| dotnet-sdk-6.0 | latest |
 | dotnet-sdk-5.0 | latest |
 | default-jre | latest |
 | elasticsearch-oss| 7.10.2 |

--- a/docs/devcontainer-quickstart.md
+++ b/docs/devcontainer-quickstart.md
@@ -1,6 +1,4 @@
-# Development with Visual Studio Code
-
-## Development Container
+# Development container for Visual Studio Code
 
 This repo provides a container that can be used directly for local development. If you never used a development container, we suggest reading first the following documentation for system requirements and installation steps.
 
@@ -42,7 +40,7 @@ vscode ➜ ~/elasticsearch-7.10.2 $ ./bin/elasticsearch
 [2021-11-10T10:29:41,444][INFO ][o.e.g.GatewayService     ] [9f911f701eba] recovered [0] indices into cluster_state
 ```
 
-Open a web browser and targets http://localhost:9200/. Similar json must be returned.
+Open a web browser and target http://localhost:9200/. Similar json must be returned.
 
 ```json
 {
@@ -87,7 +85,7 @@ vscode ➜ ~/kibana-7.10.2-linux-x86_64 $ ./bin/kibana
   log   [10:32:18.851] [info][server][Kibana][http] http server running at http://localhost:5601
 ```
 
-Open a web browser and targets http://localhost:5601/ to access the Kibana UI.
+Open a web browser and target http://localhost:5601/ to access the Kibana UI.
 
 ### Important
 
@@ -110,6 +108,4 @@ elasticsearch.hosts: ["http://localhost:8080"]
 
 ## What's next !?
 
-Check the [development](./development.md) instructions to configure correctly K2Bridge application settings. 
-
-
+Check the [development](./development.md) instructions to configure correctly K2Bridge application settings.

--- a/docs/development-container.md
+++ b/docs/development-container.md
@@ -16,11 +16,12 @@ The following packages are installed on top of this base image.
 | terraform | 1.0.9 |
 | azure-cli | latest |
 | helm | latest |
+| mitmproxy | 7.0.4 |
 | dotnet-sdk-3.1 | latest |
 | dotnet-sdk-5.0 | latest |
 | default-jre | latest |
-| elasticsearch-oss| 6.8.20 |
-| kibana-oss | 6.8.20 |
+| elasticsearch-oss| 7.10.2 |
+| kibana-oss | 7.10.2 |
 
 Elasticsearch and Kibana are available at `/home/vscode`; and dev container will start using vscode non-root user. For reference, you cannot start elasticsearch using root user, an exception will occur.
 
@@ -31,34 +32,33 @@ Elasticsearch and Kibana are available at `/home/vscode`; and dev container will
 ```bash
 vscode ➜ /workspaces/K2Bridge (feature/devcontainer ✗) $ cd $home
 vscode ➜ ~ $ ls
-elasticsearch-6.8.20  kibana-6.8.20-linux-x86_64
-vscode ➜ ~ $ cd elasticsearch-6.8.20/
-vscode ➜ ~/elasticsearch-6.8.20 $ ./bin/elasticsearch
+elasticsearch-7.10.2  kibana-7.10.2-linux-x86_64
+vscode ➜ ~ $ cd elasticsearch-7.10.2/
+vscode ➜ ~/elasticsearch-7.10.2 $ ./bin/elasticsearch
 
 [...]
-[2021-11-05T13:52:23,448][INFO ][o.e.h.n.Netty4HttpServerTransport] [Aj2lFRl] publish_address {127.0.0.1:9200}, bound_addresses {127.0.0.1:9200}
-[2021-11-05T13:52:23,449][INFO ][o.e.n.Node               ] [Aj2lFRl] started
-[2021-11-05T13:52:23,728][INFO ][o.e.g.GatewayService     ] [Aj2lFRl] recovered [1] indices into cluster_state
-[2021-11-05T13:52:24,100][INFO ][o.e.c.r.a.AllocationService] [Aj2lFRl] Cluster health status changed from [RED] to [GREEN] (reason: [shards started [[.kibana_1][0]] ...]).
+[2021-11-10T10:29:41,395][INFO ][o.e.h.AbstractHttpServerTransport] [9f911f701eba] publish_address {127.0.0.1:9200}, bound_addresses {127.0.0.1:9200}
+[2021-11-10T10:29:41,397][INFO ][o.e.n.Node               ] [9f911f701eba] started
+[2021-11-10T10:29:41,444][INFO ][o.e.g.GatewayService     ] [9f911f701eba] recovered [0] indices into cluster_state
 ```
 
 Open a web browser and targets http://localhost:9200/. Similar json must be returned.
 
 ```json
 {
-  "name" : "Aj2lFRl",
+  "name" : "9f911f701eba",
   "cluster_name" : "elasticsearch",
-  "cluster_uuid" : "RqGRp20aRlO2b7DTkPjmDg",
+  "cluster_uuid" : "IfhhAPkOT8m_zfIkUfHtWg",
   "version" : {
-    "number" : "6.8.20",
+    "number" : "7.10.2",
     "build_flavor" : "oss",
     "build_type" : "tar",
-    "build_hash" : "c859302",
-    "build_date" : "2021-10-07T22:00:24.085009Z",
+    "build_hash" : "747e1cc71def077253878a59143c1f785afa92b9",
+    "build_date" : "2021-01-13T00:42:12.435326Z",
     "build_snapshot" : false,
-    "lucene_version" : "7.7.3",
-    "minimum_wire_compatibility_version" : "5.6.0",
-    "minimum_index_compatibility_version" : "5.0.0"
+    "lucene_version" : "8.7.0",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
   },
   "tagline" : "You Know, for Search"
 }
@@ -72,18 +72,19 @@ Then start Kibana.
 ```bash
 vscode ➜ /workspaces/K2Bridge (feature/devcontainer ✗) $ cd $home
 vscode ➜ ~ $ ls
-elasticsearch-6.8.20  kibana-6.8.20-linux-x86_64
-vscode ➜ ~ $ cd kibana-6.8.20-linux-x86_64/
-vscode ➜ ~/kibana-6.8.20-linux-x86_64 $ ./bin/kibana
-  log   [14:03:45.726] [info][status][plugin:kibana@6.8.20] Status changed from uninitialized to green - Ready
-  log   [14:03:45.773] [info][status][plugin:elasticsearch@6.8.20] Status changed from uninitialized to yellow - Waiting for Elasticsearch
-  log   [14:03:45.780] [info][status][plugin:console@6.8.20] Status changed from uninitialized to green - Ready
-  log   [14:03:45.797] [info][status][plugin:interpreter@6.8.20] Status changed from uninitialized to green - Ready
-  log   [14:03:45.813] [info][status][plugin:metrics@6.8.20] Status changed from uninitialized to green - Ready
-  log   [14:03:45.832] [info][status][plugin:tile_map@6.8.20] Status changed from uninitialized to green - Ready
-  log   [14:03:45.977] [info][status][plugin:timelion@6.8.20] Status changed from uninitialized to green - Ready
-  log   [14:03:46.042] [info][status][plugin:elasticsearch@6.8.20] Status changed from yellow to green - Ready
-  log   [14:03:46.159] [info][listening] Server running at http://localhost:5601
+elasticsearch-7.10.2  kibana-7.10.2-linux-x86_64
+vscode ➜ ~ $ cd kibana-7.10.2-linux-x86_64/
+vscode ➜ ~/kibana-7.10.2-linux-x86_64 $ ./bin/kibana
+  log   [10:32:16.542] [info][plugins-service] Plugin "visTypeXy" is disabled.
+  log   [10:32:16.711] [info][plugins-system] Setting up [40] plugins: [usageCollection,telemetryCollectionManager,telemetry,kibanaUsageCollection,securityOss,newsfeed,mapsLegacy,kibanaLegacy,share,legacyExport,embeddable,expressions,data,home,console,apmOss,management,indexPatternManagement,advancedSettings,savedObjects,dashboard,visualizations,inputControlVis,visTypeVega,visTypeTimelion,timelion,visTypeTable,visTypeMarkdown,tileMap,regionMap,visualize,esUiShared,charts,visTypeTimeseries,visTypeVislib,visTypeTagcloud,visTypeMetric,discover,savedObjectsManagement,bfetch]
+  log   [10:32:17.005] [info][savedobjects-service] Waiting until all Elasticsearch nodes are compatible with Kibana before starting saved objects migrations...
+  log   [10:32:17.061] [info][savedobjects-service] Starting saved objects migrations
+  log   [10:32:17.101] [info][savedobjects-service] Creating index .kibana_1.
+  log   [10:32:18.047] [info][savedobjects-service] Pointing alias .kibana to .kibana_1.
+  log   [10:32:18.162] [info][savedobjects-service] Finished in 1071ms.
+  log   [10:32:18.179] [info][plugins-system] Starting [40] plugins: [usageCollection,telemetryCollectionManager,telemetry,kibanaUsageCollection,securityOss,newsfeed,mapsLegacy,kibanaLegacy,share,legacyExport,embeddable,expressions,data,home,console,apmOss,management,indexPatternManagement,advancedSettings,savedObjects,dashboard,visualizations,inputControlVis,visTypeVega,visTypeTimelion,timelion,visTypeTable,visTypeMarkdown,tileMap,regionMap,visualize,esUiShared,charts,visTypeTimeseries,visTypeVislib,visTypeTagcloud,visTypeMetric,discover,savedObjectsManagement,bfetch]
+  log   [10:32:18.793] [info][listening] Server running at http://localhost:5601
+  log   [10:32:18.851] [info][server][Kibana][http] http server running at http://localhost:5601
 ```
 
 Open a web browser and targets http://localhost:5601/ to access the Kibana UI.
@@ -96,8 +97,8 @@ Under Kibana's '*config*' directory, edit the *kibana.yml* file.
 
 ```bash
 vscode ➜ /workspaces/K2Bridge (feature/devcontainer ✗) $ cd $home
-vscode ➜ ~ $ cd kibana-6.8.20-linux-x86_64/
-vscode ➜ ~/kibana-6.8.20-linux-x86_64 $ code ./config/kibana.yml
+vscode ➜ ~ $ cd kibana-7.10.2-linux-x86_64/
+vscode ➜ ~/kibana-7.10.2-linux-x86_64 $ code ./config/kibana.yml 
 ```
 
 And add the following line. Note that this assumes that the bridge will listen on port 8080. All requests will be forwarded to bridge. 


### PR DESCRIPTION
# PR Request

This container is based on image `mcr.microsoft.com/vscode/devcontainers/base:0-ubuntu20.04` which already contains a set of dev tools and linux packages.

The following packages are installed on top of this base image.

| Tool / library | Version |
|----------------|---------|
| terraform | 1.0.9 |
| azure-cli | latest |
| helm | latest |
| mitmproxy | 7.0.4 |
| dotnet-sdk-6.0 | latest |
| dotnet-sdk-5.0 | latest |
| default-jre | latest |
| elasticsearch-oss| 7.10.2 |
| kibana-oss | 7.10.2 |

Added a change to devcontainer.json to mount local user ./ssh folder. (used for github authentication with ssh).

