### PR TITLE
feat: Implementation of sum metric aggregation

### DIFF
--- a/K2Bridge.Tests.End2End/ParallelApiTest.cs
+++ b/K2Bridge.Tests.End2End/ParallelApiTest.cs
@@ -199,10 +199,10 @@ namespace K2Bridge.Tests.End2End
         }
 
         [Test]
-        [Description("/_msearch visualization query with date histogram and two metrics (count + max)")]
-        public void CompareElasticKusto_WhenMSearchVizDateHistogramTwoMetrics_ResponsesAreEquivalent()
+        [Description("/_msearch visualization query with date histogram and aggregation metrics")]
+        public void CompareElasticKusto_WhenMSearchVizDateHistogramMetrics_ResponsesAreEquivalent()
         {
-            ParallelQuery($"{FLIGHTSDIR}/MSearch_Viz_DateHistogram_TwoMetrics.json");
+            ParallelQuery($"{FLIGHTSDIR}/MSearch_Viz_DateHistogram_Metrics.json");
         }
 
         private static void AssertJsonIdentical(JToken k2, JToken es)

--- a/K2Bridge.Tests.End2End/TestElasticClient.cs
+++ b/K2Bridge.Tests.End2End/TestElasticClient.cs
@@ -134,11 +134,14 @@ namespace K2Bridge.Tests.End2End
                 DeleteValue(result, "responses[*].hits.hits[*].highlight");
             }
 
-            // backend query isn't something we want to compare since it's unique to K2
+            // Backend query isn't something we want to compare since it's unique to K2
             DeleteValue(result, "responses[*]._backendQuery");
 
             // Ignore fields.hour_of_day (script_fields are currently no supported)
             DeleteValue(result, "responses[*].hits.hits[*].fields.hour_of_day");
+
+            // Normalize all float metric values with fixed number of decimal
+            NormalizeMetricValues(result, "responses[*].aggregations..buckets..value");
 
             return result;
         }
@@ -286,6 +289,25 @@ namespace K2Bridge.Tests.End2End
                 var originalTimestamp = (DateTime)v.Value;
                 var normalizedTimestamp = TimeZoneInfo.ConvertTimeToUtc(originalTimestamp);
                 v.Value = normalizedTimestamp.ToString("o", CultureInfo.InvariantCulture);
+            }
+        }
+
+        // <summary>
+        /// Normalize metric values with fixed number of decimals.
+        /// </summary>
+        /// <param name="parent">JSON element at which to start search.</param>
+        /// <param name="jsonPath">JSONPath search pattern for metric values to normalize.</param>
+        private static void NormalizeMetricValues(JToken parent, string jsonPath)
+        {
+            var tokens = parent.SelectTokens(jsonPath);
+            foreach (JValue v in tokens)
+            {
+                if (v.Type == JTokenType.Float)
+                {
+                    var originalMetricValue = (double)v.Value;
+                    var normalizedMetricValue = originalMetricValue.ToString("F6", CultureInfo.InvariantCulture);
+                    v.Value = normalizedMetricValue;
+                }
             }
         }
 

--- a/K2Bridge.Tests.End2End/TestElasticClient.cs
+++ b/K2Bridge.Tests.End2End/TestElasticClient.cs
@@ -141,6 +141,8 @@ namespace K2Bridge.Tests.End2End
             DeleteValue(result, "responses[*].hits.hits[*].fields.hour_of_day");
 
             // Normalize all float metric values with fixed number of decimal
+            // TODO: Need to update NormalizeMetricValues for bucket returning values instead of value
+            // workitem 15247
             NormalizeMetricValues(result, "responses[*].aggregations..buckets..value");
 
             return result;

--- a/K2Bridge.Tests.End2End/flights/MSearch_Viz_DateHistogram_Metrics.json
+++ b/K2Bridge.Tests.End2End/flights/MSearch_Viz_DateHistogram_Metrics.json
@@ -9,12 +9,17 @@
             },
             "aggs": {
                 "3": {
-                    "max": {
-                        "field": "AvgTicketPrice"
+                    "avg": {
+                        "field": "DistanceKilometers"
                     }
                 },
                 "4": {
                     "max": {
+                        "field": "DistanceKilometers"
+                    }
+                },
+                "5": {
+                    "sum": {
                         "field": "DistanceKilometers"
                     }
                 }

--- a/K2Bridge.Tests.UnitTests/JsonConverters/AggregationConverterTests.cs
+++ b/K2Bridge.Tests.UnitTests/JsonConverters/AggregationConverterTests.cs
@@ -35,21 +35,27 @@ namespace UnitTests.K2Bridge.JsonConverters
         private const string AvgAggregation = @"
             {""aggs"": { 
                 ""2"": {
-                    ""avg"" : { ""field"" : ""grade"" } 
+                    ""avg"" : { 
+                        ""field"" : ""metric"" 
+                    } 
                 }
             }}";
 
-        private const string AvgEmptyFieldsAggregation = @"
-        {""aggs"": { 
-            ""2"": {
-                ""avg"" : { ""nofield"" : ""grade"" } 
-            }
-        }}";
+        private const string SumAggregation = @"
+            {""aggs"": { 
+                ""2"": {
+                    ""sum"" : {
+                        ""field"" : ""metric"" 
+                    } 
+                }
+            }}";
 
         private const string NoAggAggregation = @"
         {""aggs"": { 
             ""2"": {
-                ""noagg"" : { ""field"" : ""grade"" } 
+                ""noagg"" : { 
+                    ""field"" : ""metric"" 
+                    } 
             }
         }}";
 
@@ -95,7 +101,7 @@ namespace UnitTests.K2Bridge.JsonConverters
                     { "2", new Aggregation() {
                         PrimaryAggregation = new AvgAggregation {
                             FieldAlias = "_2",
-                            FieldName = "grade",
+                            FieldName = "metric",
                             },
                         SubAggregations = new Dictionary<string, Aggregation>(),
                         }
@@ -103,15 +109,15 @@ namespace UnitTests.K2Bridge.JsonConverters
                 },
         };
 
-        private static readonly Aggregation ExpectedNoFieldsAvgAggregation = new Aggregation()
+        private static readonly Aggregation ExpectedValidSumAggregation = new Aggregation()
         {
             PrimaryAggregation = null,
             SubAggregations = new Dictionary<string, Aggregation>
                 {
                     { "2", new Aggregation() {
-                        PrimaryAggregation = new AvgAggregation {
+                        PrimaryAggregation = new SumAggregation {
                             FieldAlias = "_2",
-                            FieldName = null,
+                            FieldName = "metric",
                             },
                         SubAggregations = new Dictionary<string, Aggregation>(),
                         }
@@ -136,7 +142,7 @@ namespace UnitTests.K2Bridge.JsonConverters
             new TestCaseData(DateHistogramAggregation, ExpectedValidDateHistogramAggregation).SetName("JsonDeserializeObject_WithAggregationValidDateHistogram_DeserializedCorrectly"),
             new TestCaseData(CardinalityAggregation, ExpectedValidCardinalityAggregation).SetName("JsonDeserializeObject_WithAggregationValidCardinality_DeserializedCorrectly"),
             new TestCaseData(AvgAggregation, ExpectedValidAvgAggregation).SetName("JsonDeserializeObject_WithAggregationValidAvg_DeserializedCorrectly"),
-            new TestCaseData(AvgEmptyFieldsAggregation, ExpectedNoFieldsAvgAggregation).SetName("JsonDeserializeObject_WithAggregationNoFieldsAvg_DeserializedCorrectly"),
+            new TestCaseData(SumAggregation, ExpectedValidSumAggregation).SetName("JsonDeserializeObject_WithAggregationValidSum_DeserializedCorrectly"),
             new TestCaseData(NoAggAggregation, ExpectedNoAggAggregation).SetName("JsonDeserializeObject_WithNoAgg_DeserializedCorrectly"),
         };
 

--- a/K2Bridge.Tests.UnitTests/JsonConverters/AggregationConverterTests.cs
+++ b/K2Bridge.Tests.UnitTests/JsonConverters/AggregationConverterTests.cs
@@ -41,6 +41,15 @@ namespace UnitTests.K2Bridge.JsonConverters
                 }
             }}";
 
+        private const string AvgEmptyFieldsAggregation = @"
+            {""aggs"": { 
+                ""2"": {
+                    ""avg"" : { 
+                        ""nofield"" : ""metric"" 
+                    } 
+                }
+            }}";
+
         private const string SumAggregation = @"
             {""aggs"": { 
                 ""2"": {
@@ -109,6 +118,22 @@ namespace UnitTests.K2Bridge.JsonConverters
                 },
         };
 
+        private static readonly Aggregation ExpectedNoFieldsAvgAggregation = new Aggregation()
+        {
+            PrimaryAggregation = null,
+            SubAggregations = new Dictionary<string, Aggregation>
+                {
+                    { "2", new Aggregation() {
+                        PrimaryAggregation = new AvgAggregation {
+                            FieldAlias = "_2",
+                            FieldName = null,
+                            },
+                        SubAggregations = new Dictionary<string, Aggregation>(),
+                        }
+                    },
+                },
+        };
+
         private static readonly Aggregation ExpectedValidSumAggregation = new Aggregation()
         {
             PrimaryAggregation = null,
@@ -142,6 +167,7 @@ namespace UnitTests.K2Bridge.JsonConverters
             new TestCaseData(DateHistogramAggregation, ExpectedValidDateHistogramAggregation).SetName("JsonDeserializeObject_WithAggregationValidDateHistogram_DeserializedCorrectly"),
             new TestCaseData(CardinalityAggregation, ExpectedValidCardinalityAggregation).SetName("JsonDeserializeObject_WithAggregationValidCardinality_DeserializedCorrectly"),
             new TestCaseData(AvgAggregation, ExpectedValidAvgAggregation).SetName("JsonDeserializeObject_WithAggregationValidAvg_DeserializedCorrectly"),
+            new TestCaseData(AvgEmptyFieldsAggregation, ExpectedNoFieldsAvgAggregation).SetName("JsonDeserializeObject_WithAggregationNoFieldsAvg_DeserializedCorrectly"),
             new TestCaseData(SumAggregation, ExpectedValidSumAggregation).SetName("JsonDeserializeObject_WithAggregationValidSum_DeserializedCorrectly"),
             new TestCaseData(NoAggAggregation, ExpectedNoAggAggregation).SetName("JsonDeserializeObject_WithNoAgg_DeserializedCorrectly"),
         };

--- a/K2Bridge.Tests.UnitTests/Visitors/AggregationVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/AggregationVisitorTests.cs
@@ -87,7 +87,7 @@ namespace UnitTests.K2Bridge.Visitors
             return aggregateClause.KustoQL;
         }
 
-        [TestCase(ExpectedResult = "_A=sum(fieldA)")]
+        [TestCase(ExpectedResult = "['_A']=sum(fieldA)")]
         public string AggregationVisit_WithSumAgg_ReturnsSumPrimary()
         {
             var aggregateClause = new Aggregation()
@@ -101,7 +101,7 @@ namespace UnitTests.K2Bridge.Visitors
             return aggregateClause.KustoQL;
         }
 
-        [TestCase(ExpectedResult = "_B=sum(fieldB), _A=sum(fieldA)")]
+        [TestCase(ExpectedResult = "['_B']=sum(fieldB), ['_A']=sum(fieldA)")]
         public string AggregationVisit_WithSubSumAgg_ReturnsSumAggregates()
         {
             var aggregateClause = new Aggregation()

--- a/K2Bridge.Tests.UnitTests/Visitors/AggregationVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/AggregationVisitorTests.cs
@@ -86,5 +86,37 @@ namespace UnitTests.K2Bridge.Visitors
 
             return aggregateClause.KustoQL;
         }
+
+        [TestCase(ExpectedResult = "_A=sum(fieldA)")]
+        public string AggregationVisit_WithSumAgg_ReturnsSumPrimary()
+        {
+            var aggregateClause = new Aggregation()
+            {
+                PrimaryAggregation = new SumAggregation() { FieldName = "fieldA", FieldAlias = "_A" },
+            };
+
+            var visitor = new ElasticSearchDSLVisitor(SchemaRetrieverMock.CreateMockSchemaRetriever());
+            visitor.Visit(aggregateClause);
+
+            return aggregateClause.KustoQL;
+        }
+
+        [TestCase(ExpectedResult = "_B=sum(fieldB), _A=sum(fieldA)")]
+        public string AggregationVisit_WithSubSumAgg_ReturnsSumAggregates()
+        {
+            var aggregateClause = new Aggregation()
+            {
+                PrimaryAggregation = new SumAggregation() { FieldName = "fieldA", FieldAlias = "_A" },
+                SubAggregations = new Dictionary<string, Aggregation>
+                {
+                    { "sub", new Aggregation() { PrimaryAggregation = new SumAggregation { FieldName = "fieldB", FieldAlias = "_B" } } },
+                },
+            };
+
+            var visitor = new ElasticSearchDSLVisitor(SchemaRetrieverMock.CreateMockSchemaRetriever());
+            visitor.Visit(aggregateClause);
+
+            return aggregateClause.KustoQL;
+        }
     }
 }

--- a/K2Bridge/JsonConverters/LeafAggregationConverter.cs
+++ b/K2Bridge/JsonConverters/LeafAggregationConverter.cs
@@ -44,6 +44,10 @@ namespace K2Bridge.JsonConverters
                 case "max":
                     leafAggregation = first.Value.ToObject<MaxAggregation>(serializer);
                     break;
+
+                case "sum":
+                    leafAggregation = first.Value.ToObject<SumAggregation>(serializer);
+                    break;
             }
 
             return leafAggregation;

--- a/K2Bridge/Models/Request/Aggregations/SumAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/SumAggregation.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+namespace K2Bridge.Models.Request.Aggregations
+{
+    using K2Bridge.JsonConverters;
+    using K2Bridge.Visitors;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// A single-value metrics aggregation that computes the sum of numeric values that are extracted from the aggregated documents.
+    /// </summary>
+    [JsonConverter(typeof(AggregationFieldConverter))]
+    internal class SumAggregation : MetricAggregation
+    {
+        /// <inheritdoc/>
+        public override void Accept(IVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/K2Bridge/Visitors/IVisitor.cs
+++ b/K2Bridge/Visitors/IVisitor.cs
@@ -86,6 +86,12 @@ namespace K2Bridge.Visitors
         void Visit(MaxAggregation maxAggregation);
 
         /// <summary>
+        /// Accepts a given visitable object and builds a Kusto query.
+        /// </summary>
+        /// <param name="sumAggregation">The Sum Aggregations to visit.</param>
+        void Visit(SumAggregation sumAggregation);
+
+        /// <summary>
         /// Accepts a query string clause, parses the phrase to a lucene query, and builds a Kusto query based on the lucene query.
         /// </summary>
         /// <param name="queryStringClause">The query string clause.</param>

--- a/K2Bridge/Visitors/KustoQLOperators.cs
+++ b/K2Bridge/Visitors/KustoQLOperators.cs
@@ -32,6 +32,7 @@ namespace K2Bridge.Visitors
         public const string DCount = "dcount";
         public const string Avg = "avg";
         public const string Max = "max";
+        public const string Sum = "sum";
         public const string IsNotNull = "isnotnull";
         public const string StartOfWeek = "startofweek";
         public const string StartOfMonth = "startofmonth";

--- a/K2Bridge/Visitors/MetricAggregationVisitor.cs
+++ b/K2Bridge/Visitors/MetricAggregationVisitor.cs
@@ -46,7 +46,7 @@ namespace K2Bridge.Visitors
             Ensure.IsNotNull(sumAggregation, nameof(sumAggregation));
             EnsureClause.StringIsNotNullOrEmpty(sumAggregation.FieldName, sumAggregation.FieldName, ExceptionMessage);
 
-            sumAggregation.KustoQL = $"{sumAggregation.FieldAlias}={KustoQLOperators.Sum}({sumAggregation.FieldName})";
+            sumAggregation.KustoQL = $"['{sumAggregation.FieldAlias}']={KustoQLOperators.Sum}({sumAggregation.FieldName})";
         }
     }
 }

--- a/K2Bridge/Visitors/MetricAggregationVisitor.cs
+++ b/K2Bridge/Visitors/MetricAggregationVisitor.cs
@@ -39,5 +39,14 @@ namespace K2Bridge.Visitors
 
             maxAggregation.KustoQL = $"{maxAggregation.FieldAlias}={KustoQLOperators.Max}({maxAggregation.FieldName})";
         }
+
+        /// <inheritdoc/>
+        public void Visit(SumAggregation sumAggregation)
+        {
+            Ensure.IsNotNull(sumAggregation, nameof(sumAggregation));
+            EnsureClause.StringIsNotNullOrEmpty(sumAggregation.FieldName, sumAggregation.FieldName, ExceptionMessage);
+
+            sumAggregation.KustoQL = $"{sumAggregation.FieldAlias}={KustoQLOperators.Sum}({sumAggregation.FieldName})";
+        }
     }
 }


### PR DESCRIPTION
# feat: Implementation of sum metric aggregation

- [x] Add support for SumAggregation
- [x] Add unit tests
- [x] Update end-to-end tests

Note: For e2e tests, float metrics values have been normalized to have a fixed number of digits (set to 6).