### PR TITLE
Fix ranged queries

### DIFF
--- a/K2Bridge.Tests.UnitTests/Visitors/LuceneNet/LuceneRangeVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/LuceneNet/LuceneRangeVisitorTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests.K2Bridge.Visitors.LuceneNet
                 Throws.TypeOf<IllegalClauseException>());
         }
 
-        [TestCase(ExpectedResult = "days >= 2 and days < 6")]
+        [TestCase(ExpectedResult = "days >= 2 and days <= 6")]
         public string Visit_WithValidRangeQuery_ReturnsValidResponse()
         {
             var rangeQuery = new LuceneRangeQuery

--- a/K2Bridge.Tests.UnitTests/Visitors/RangeClauseVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/RangeClauseVisitorTests.cs
@@ -13,8 +13,8 @@ namespace UnitTests.K2Bridge.Visitors
     public enum RangeType
     {
         Wildcard,
-        Open,
-        Closed,
+        Exclusive,
+        Inclusive,
     }
 
     [TestFixture]
@@ -22,42 +22,42 @@ namespace UnitTests.K2Bridge.Visitors
     {
         // Numeric RangeClause Query Tests
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > 0 and MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > 0 and MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= 0 and MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= 0 and MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > 0 and MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > 0 and MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= 0 and MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= 0 and MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidRangeClauseVisitNumberBetweenTwoInts(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateRangeClause("0", "10", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > 0 and MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > 0 and MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= 0 and MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= 0 and MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > 0 and MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > 0 and MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= 0 and MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= 0 and MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidRangeClauseVisitNumberBetweenIntAndDecimal(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateRangeClause("0", "10.10", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > 10.10 and MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > 10.10 and MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= 10.10 and MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= 10.10 and MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > 10.10 and MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > 10.10 and MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= 10.10 and MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= 10.10 and MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidRangeClauseVisitNumberBetweenTwoDecimals(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateRangeClause("10.10", "20.20", minRange, maxRange));
@@ -65,56 +65,56 @@ namespace UnitTests.K2Bridge.Visitors
 
         // Time RangeClause Query Tests
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidTimeRangeClauseVisitNumberBetweenTwoInts(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateTimeRangeClause("0", "10", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidTimeRangeClauseVisitNumberBetweenIntAndDecimal(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateTimeRangeClause("0", "10.10", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10) and MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10) and MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidTimeRangeClauseVisitNumberBetweenTwoDecimals(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateTimeRangeClause("10.10", "20.20", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\") and MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\") and MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\") and MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\") and MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\") and MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\") and MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\") and MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\") and MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidDateRange_ReturnsValidResponse(RangeType minRange, RangeType maxRange)
         {
             return DateRangeClauseToKQL(CreateDateRangeClause("2020-01-01 00:00", "2020-02-22 10:00", minRange, maxRange));
@@ -125,10 +125,10 @@ namespace UnitTests.K2Bridge.Visitors
             return new RangeClause()
             {
                 FieldName = "MyField",
-                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Closed ? min : null),
-                GTValue = minRange == RangeType.Open ? min : null,
-                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Closed ? max : null),
-                LTValue = maxRange == RangeType.Open ? max : null,
+                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Inclusive ? min : null),
+                GTValue = minRange == RangeType.Exclusive ? min : null,
+                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Inclusive ? max : null),
+                LTValue = maxRange == RangeType.Exclusive ? max : null,
                 Format = null,
             };
         }
@@ -138,10 +138,10 @@ namespace UnitTests.K2Bridge.Visitors
             return new RangeClause()
             {
                 FieldName = "MyField",
-                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Closed ? min : null),
-                GTValue = minRange == RangeType.Open ? min : null,
-                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Closed ? max : null),
-                LTValue = maxRange == RangeType.Open ? max : null,
+                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Inclusive ? min : null),
+                GTValue = minRange == RangeType.Exclusive ? min : null,
+                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Inclusive ? max : null),
+                LTValue = maxRange == RangeType.Exclusive ? max : null,
                 Format = "epoch_millis",
             };
         }
@@ -151,10 +151,10 @@ namespace UnitTests.K2Bridge.Visitors
             return new RangeClause()
             {
                 FieldName = "MyField",
-                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Closed ? min : null),
-                GTValue = minRange == RangeType.Open ? min : null,
-                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Closed ? max : null),
-                LTValue = maxRange == RangeType.Open ? max : null,
+                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Inclusive ? min : null),
+                GTValue = minRange == RangeType.Exclusive ? min : null,
+                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Inclusive ? max : null),
+                LTValue = maxRange == RangeType.Exclusive ? max : null,
                 Format = null,
             };
         }

--- a/K2Bridge.Tests.UnitTests/Visitors/RangeClauseVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/RangeClauseVisitorTests.cs
@@ -10,102 +10,151 @@ namespace UnitTests.K2Bridge.Visitors
     using global::K2Bridge.Visitors;
     using NUnit.Framework;
 
+    public enum RangeType
+    {
+        Wildcard,
+        Open,
+        Closed,
+    }
+
     [TestFixture]
     public class RangeClauseVisitorTests
     {
         // Numeric RangeClause Query Tests
-        [TestCase(
-            ExpectedResult = "MyField >= 0 and MyField < 10",
-            TestName="Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse")]
-        public string TestValidRangeClauseVisitNumberBetweenTwoInts()
+        [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
+        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > 0 and MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > 0 and MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= 0 and MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= 0 and MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        public string TestValidRangeClauseVisitNumberBetweenTwoInts(RangeType minRange, RangeType maxRange)
         {
-            return RangeClauseToKQL(CreateRangeClause("0", "10"));
+            return RangeClauseToKQL(CreateRangeClause("0", "10", minRange, maxRange));
         }
 
-        [TestCase(
-            ExpectedResult = "MyField >= 0 and MyField < 10.10",
-            TestName="Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse")]
-        public string TestValidRangeClauseVisitNumberBetweenIntAndDecimal()
+        [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
+        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > 0 and MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > 0 and MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= 0 and MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= 0 and MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        public string TestValidRangeClauseVisitNumberBetweenIntAndDecimal(RangeType minRange, RangeType maxRange)
         {
-            return RangeClauseToKQL(CreateRangeClause("0", "10.10"));
+            return RangeClauseToKQL(CreateRangeClause("0", "10.10", minRange, maxRange));
         }
 
-        [TestCase(
-            ExpectedResult = "MyField >= 10.10 and MyField < 20.20",
-            TestName="Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse")]
-        public string TestValidRangeClauseVisitNumberBetweenTwoDecimalss()
+        [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
+        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > 10.10 and MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > 10.10 and MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= 10.10 and MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= 10.10 and MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        public string TestValidRangeClauseVisitNumberBetweenTwoDecimals(RangeType minRange, RangeType maxRange)
         {
-            return RangeClauseToKQL(CreateRangeClause("10.10", "20.20"));
+            return RangeClauseToKQL(CreateRangeClause("10.10", "20.20", minRange, maxRange));
         }
 
         // Time RangeClause Query Tests
-        [TestCase(
-            ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)",
-            TestName="Visit_WithValidRangeBetweenInts_ReturnsValidResponse")]
-        public string TestValidTimeRangeClauseVisitNumberBetweenTwoInts()
+        [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
+        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        public string TestValidTimeRangeClauseVisitNumberBetweenTwoInts(RangeType minRange, RangeType maxRange)
         {
-            return RangeClauseToKQL(CreateTimeRangeClause("0", "10"));
+            return RangeClauseToKQL(CreateTimeRangeClause("0", "10", minRange, maxRange));
         }
 
-        [TestCase(
-            ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)",
-            TestName="Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse")]
-        public string TestValidTimeRangeClauseVisitNumberBetweenIntAndDecimal()
+        [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
+        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        public string TestValidTimeRangeClauseVisitNumberBetweenIntAndDecimal(RangeType minRange, RangeType maxRange)
         {
-            return RangeClauseToKQL(CreateTimeRangeClause("0", "10.10"));
+            return RangeClauseToKQL(CreateTimeRangeClause("0", "10.10", minRange, maxRange));
         }
 
-        [TestCase(
-            ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)",
-            TestName="Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse")]
-        public string TestValidTimeRangeClauseVisitNumberBetweenTwoDecimalss()
+        [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
+        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10) and MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        public string TestValidTimeRangeClauseVisitNumberBetweenTwoDecimals(RangeType minRange, RangeType maxRange)
         {
-            return RangeClauseToKQL(CreateTimeRangeClause("10.10", "20.20"));
+            return RangeClauseToKQL(CreateTimeRangeClause("10.10", "20.20", minRange, maxRange));
         }
 
-        [TestCase(
-            ExpectedResult = "MyField >= todatetime(\"2020-01-01 00:00\") and MyField < todatetime(\"2020-02-22 10:00\")",
-            TestName = "Visit_ValidDateRange_ReturnsValidResponse")]
-        public string TestValidDateRange_ReturnsValidResponse()
+        [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
+        [TestCase(RangeType.Wildcard, RangeType.Open, ExpectedResult = "MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Closed, ExpectedResult = "MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Open, RangeType.Wildcard, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Open, RangeType.Open, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\") and MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Open, RangeType.Closed, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\") and MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Closed, RangeType.Wildcard, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Closed, RangeType.Open, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\") and MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Closed, RangeType.Closed, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\") and MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        public string TestValidDateRange_ReturnsValidResponse(RangeType minRange, RangeType maxRange)
         {
-            return DateRangeClauseToKQL(CreateDateRangeClause("2020-01-01 00:00", "2020-02-22 10:00"));
+            return DateRangeClauseToKQL(CreateDateRangeClause("2020-01-01 00:00", "2020-02-22 10:00", minRange, maxRange));
         }
 
-        private static RangeClause CreateRangeClause(string min, string max)
+        private static RangeClause CreateRangeClause(string min, string max, RangeType minRange, RangeType maxRange)
         {
             return new RangeClause()
             {
                 FieldName = "MyField",
-                GTEValue = min,
-                GTValue = null,
-                LTEValue = null,
-                LTValue = max,
+                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Closed ? min : null),
+                GTValue = minRange == RangeType.Open ? min : null,
+                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Closed ? max : null),
+                LTValue = maxRange == RangeType.Open ? max : null,
                 Format = null,
             };
         }
 
-        private static RangeClause CreateTimeRangeClause(string min, string max)
+        private static RangeClause CreateTimeRangeClause(string min, string max, RangeType minRange, RangeType maxRange)
         {
             return new RangeClause()
             {
                 FieldName = "MyField",
-                GTEValue = min,
-                GTValue = null,
-                LTEValue = max,
-                LTValue = null,
+                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Closed ? min : null),
+                GTValue = minRange == RangeType.Open ? min : null,
+                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Closed ? max : null),
+                LTValue = maxRange == RangeType.Open ? max : null,
                 Format = "epoch_millis",
             };
         }
 
-        private static RangeClause CreateDateRangeClause(string min, string max)
+        private static RangeClause CreateDateRangeClause(string min, string max, RangeType minRange, RangeType maxRange)
         {
             return new RangeClause()
             {
                 FieldName = "MyField",
-                GTEValue = min,
-                GTValue = null,
-                LTEValue = null,
-                LTValue = max,
+                GTEValue = minRange == RangeType.Wildcard ? "*" : (minRange == RangeType.Closed ? min : null),
+                GTValue = minRange == RangeType.Open ? min : null,
+                LTEValue = maxRange == RangeType.Wildcard ? "*" : (maxRange == RangeType.Closed ? max : null),
+                LTValue = maxRange == RangeType.Open ? max : null,
                 Format = null,
             };
         }

--- a/K2Bridge.Tests.UnitTests/Visitors/RangeVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/RangeVisitorTests.cs
@@ -46,7 +46,7 @@ namespace UnitTests.K2Bridge.Visitors
         {
             var rangeClause = CreateRangeClause("myField", null, null, null, "5", "other");
 
-            Assert.Throws(typeof(IllegalClauseException), () => VisitRangeClause(rangeClause));
+            Assert.Throws(typeof(IllegalClauseException), () => VisitRangeClause(rangeClause, type: "integer"));
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace UnitTests.K2Bridge.Visitors
         {
             var rangeClause = CreateRangeClause("myField", "5", null, null, null, "other");
 
-            Assert.Throws(typeof(IllegalClauseException), () => VisitRangeClause(rangeClause));
+            Assert.Throws(typeof(IllegalClauseException), () => VisitRangeClause(rangeClause, type: "integer"));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace UnitTests.K2Bridge.Visitors
             Assert.Throws(typeof(IllegalClauseException), () => VisitRangeClause(rangeClause));
         }
 
-        private static string VisitRangeClause(RangeClause clause, string fieldName = "MyField", string type = "string")
+        private static string VisitRangeClause(RangeClause clause, string fieldName = "myField", string type = "string")
         {
             var visitor = VisitorTestsUtils.CreateAndVisitRootVisitor(fieldName, type);
             visitor.Visit(clause);

--- a/K2Bridge/Visitors/LuceneNet/LuceneRangeVisitor.cs
+++ b/K2Bridge/Visitors/LuceneNet/LuceneRangeVisitor.cs
@@ -23,8 +23,10 @@ namespace K2Bridge.Visitors.LuceneNet
             var rangeClause = new RangeClause
             {
                 FieldName = rangeQuery.Field,
-                GTEValue = rangeQuery.LowerTerm,
-                LTValue = rangeQuery.UpperTerm,
+                GTEValue = rangeQuery.IncludesLower ? rangeQuery.LowerTerm : null,
+                GTValue = rangeQuery.IncludesLower ? null : rangeQuery.LowerTerm,
+                LTEValue = rangeQuery.IncludesUpper ? rangeQuery.UpperTerm : null,
+                LTValue = rangeQuery.IncludesUpper ? null : rangeQuery.UpperTerm,
             };
             rangeQueryWrapper.ESQuery = rangeClause;
         }

--- a/K2Bridge/Visitors/RangeClauseVisitor.cs
+++ b/K2Bridge/Visitors/RangeClauseVisitor.cs
@@ -39,7 +39,7 @@ namespace K2Bridge.Visitors
                             FillKqlQuery(rangeClause);
                             break;
                         case ClauseFieldType.Date:
-                            FillKqlQuery(rangeClause, s => $"{KustoQLOperators.ToDateTime}(\"{DateTime.Parse(s).ToUniversalTime():o}\")");
+                            FillKqlQuery(rangeClause, s => $"{KustoQLOperators.ToDateTime}(\"{DateTime.Parse(s):o}\")");
                             break;
                         case ClauseFieldType.Text:
                             throw new NotSupportedException("Text Range is not supported.");
@@ -74,17 +74,15 @@ namespace K2Bridge.Visitors
                 _ => throw new Exception("Invalid range clause."),
             };
 
-            var gtQuery = gtOperator != null ? $"{rangeClause.FieldName} {gtOperator} {gtValue}" : string.Empty;
-            var ltQuery = ltOperator != null ? $"{rangeClause.FieldName} {ltOperator} {ltValue}" : string.Empty;
-#pragma warning disable SA1122 // Empty strings must be constants
+            var gtQuery = gtOperator != null ? $"{rangeClause.FieldName} {gtOperator} {gtValue}" : null;
+            var ltQuery = ltOperator != null ? $"{rangeClause.FieldName} {ltOperator} {ltValue}" : null;
             rangeClause.KustoQL = (gtQuery, ltQuery) switch
             {
-                ("", "") => string.Empty,
-                ("", _) => ltQuery,
-                (_, "") => gtQuery,
+                (null, null) => string.Empty,
+                (null, _) => ltQuery,
+                (_, null) => gtQuery,
                 (_, _) => $"{gtQuery} {KustoQLOperators.And} {ltQuery}",
             };
-#pragma warning restore SA1122
         }
     }
 }

--- a/K2Bridge/Visitors/RangeClauseVisitor.cs
+++ b/K2Bridge/Visitors/RangeClauseVisitor.cs
@@ -17,47 +17,74 @@ namespace K2Bridge.Visitors
         {
             Ensure.IsNotNull(rangeClause, nameof(rangeClause));
             EnsureClause.StringIsNotNullOrEmpty(rangeClause.FieldName, nameof(rangeClause.FieldName));
-            EnsureClause.IsNotNull(rangeClause.GTEValue, nameof(rangeClause.GTEValue));
 
-            // format used by Kibana 6
-            if (rangeClause.Format == "epoch_millis")
+            switch (rangeClause.Format)
             {
-                // default time filter through a rangeClause query uses epoch times with GTE+LTE
-                EnsureClause.IsNotNull(rangeClause.LTEValue, nameof(rangeClause.LTEValue));
+                // format used by Kibana 6
+                case "epoch_millis":
+                    FillKqlQuery(rangeClause, s => $"unixtime_milliseconds_todatetime({s})");
+                    break;
 
-                rangeClause.KustoQL = $"{rangeClause.FieldName} >= unixtime_milliseconds_todatetime({rangeClause.GTEValue}) {KustoQLOperators.And} {rangeClause.FieldName} <= unixtime_milliseconds_todatetime({rangeClause.LTEValue})";
+                // format used by Kibana 7
+                case "strict_date_optional_time":
+                    FillKqlQuery(rangeClause, s => $"{KustoQLOperators.ToDateTime}(\"{DateTime.Parse(s).ToUniversalTime():o}\")");
+                    break;
+
+                default:
+                    // general "is between" filter on numeric fields uses a rangeClause query with GTE+LT (not LTE like above)
+                    var t = ClauseFieldTypeProcessor.GetType(schemaRetriever, rangeClause.FieldName).Result;
+                    switch (t)
+                    {
+                        case ClauseFieldType.Numeric:
+                            FillKqlQuery(rangeClause);
+                            break;
+                        case ClauseFieldType.Date:
+                            FillKqlQuery(rangeClause, s => $"{KustoQLOperators.ToDateTime}(\"{DateTime.Parse(s).ToUniversalTime():o}\")");
+                            break;
+                        case ClauseFieldType.Text:
+                            throw new NotSupportedException("Text Range is not supported.");
+                        case ClauseFieldType.Unknown:
+                            throw new Exception($"Field name {rangeClause.FieldName} has an unknown type.");
+                        default:
+                            throw new IllegalClauseException();
+                    }
+
+                    break;
             }
+        }
 
-            // format used by Kibana 7
-            else if (rangeClause.Format == "strict_date_optional_time")
+        private static void FillKqlQuery(RangeClause rangeClause, Func<string, string> valueConverter = null)
+        {
+            valueConverter ??= s => s;
+            var (gtOperator, gtValue) = rangeClause switch
             {
-                // default time filter through a rangeClause query uses epoch times with GTE+LTE
-                EnsureClause.IsNotNull(rangeClause.LTEValue, nameof(rangeClause.LTEValue));
+                { GTValue: null, GTEValue: null } => throw new IllegalClauseException(),
+                { GTValue: "*" } or { GTEValue: "*" } => (null, null),
+                { GTValue: { } gt } => (">", valueConverter(gt)),
+                { GTEValue: { } gte } => (">=", valueConverter(gte)),
+                _ => throw new Exception("Invalid range clause."),
+            };
 
-                var gte = DateTime.Parse(rangeClause.GTEValue).ToUniversalTime().ToString("o");
-                var lte = DateTime.Parse(rangeClause.LTEValue).ToUniversalTime().ToString("o");
-
-                rangeClause.KustoQL = $"{rangeClause.FieldName} >= {KustoQLOperators.ToDateTime}(\"{gte}\") {KustoQLOperators.And} {rangeClause.FieldName} <= {KustoQLOperators.ToDateTime}(\"{lte}\")";
-            }
-            else
+            var (ltOperator, ltValue) = rangeClause switch
             {
-                // general "is between" filter on numeric fields uses a rangeClause query with GTE+LT (not LTE like above)
-                EnsureClause.IsNotNull(rangeClause.LTValue, nameof(rangeClause.LTValue));
-                var t = ClauseFieldTypeProcessor.GetType(schemaRetriever, rangeClause.FieldName).Result;
-                switch (t)
-                {
-                    case ClauseFieldType.Numeric:
-                        rangeClause.KustoQL = $"{rangeClause.FieldName} >= {rangeClause.GTEValue} and {rangeClause.FieldName} < {rangeClause.LTValue}";
-                        break;
-                    case ClauseFieldType.Date:
-                        rangeClause.KustoQL = $"{rangeClause.FieldName} >= {KustoQLOperators.ToDateTime}(\"{rangeClause.GTEValue}\") {KustoQLOperators.And} {rangeClause.FieldName} < {KustoQLOperators.ToDateTime}(\"{rangeClause.LTValue}\")";
-                        break;
-                    case ClauseFieldType.Text:
-                        throw new NotSupportedException("Text Range is not supported.");
-                    case ClauseFieldType.Unknown:
-                        throw new Exception($"Field name {rangeClause.FieldName} has an unknown type.");
-                }
-            }
+                { LTValue: null, LTEValue: null } => throw new IllegalClauseException(),
+                { LTValue: "*" } or { LTEValue: "*" } => (null, null),
+                { LTValue: { } lt } => ("<", valueConverter(lt)),
+                { LTEValue: { } lte } => ("<=", valueConverter(lte)),
+                _ => throw new Exception("Invalid range clause."),
+            };
+
+            var gtQuery = gtOperator != null ? $"{rangeClause.FieldName} {gtOperator} {gtValue}" : string.Empty;
+            var ltQuery = ltOperator != null ? $"{rangeClause.FieldName} {ltOperator} {ltValue}" : string.Empty;
+#pragma warning disable SA1122 // Empty strings must be constants
+            rangeClause.KustoQL = (gtQuery, ltQuery) switch
+            {
+                ("", "") => string.Empty,
+                ("", _) => ltQuery,
+                (_, "") => gtQuery,
+                (_, _) => $"{gtQuery} {KustoQLOperators.And} {ltQuery}",
+            };
+#pragma warning restore SA1122
         }
     }
 }


### PR DESCRIPTION
Fixes ranged queries, such as:
```
field[1 TO *]
field[* TO 2007-12-31T23:53:00Z]
field{1 to 3}
```

Due to library parsing support we still don't have:
`field[1 TO 3}`
But this code will work given that.


Still missing more extensive tests