### PR TITLE
CI - Fail on low code coverage (threshold set to 79%)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,6 +132,15 @@ stages:
         summaryFileLocation: 'coverage.cobertura.xml'
         pathToSources: '$(Build.SourcesDirectory)/K2Bridge/'
         failIfCoverageEmpty: true
+    
+    - task: BuildQualityChecks@8
+      displayName: 'Check build quality'
+      inputs:
+        checkCoverage: true # Optional
+        coverageFailOption: fixed # Optional; Valid values: build, fixed
+        coverageType: lines # Optional; Valid values: blocks, lines, branches, custom
+        coverageThreshold: '78.9' # Optional
+        coverageDeltaType: percentage # Optional; Valid values: absolute, percentage
 
     - task: AzureCLI@1
       displayName: Login to ACR


### PR DESCRIPTION
The following changes are proposed:

* Added a code build quality task
* https://marketplace.visualstudio.com/items?itemName=mspremier.BuildQualityChecks#task-parameters
* https://github.com/MicrosoftPremier/VstsExtensions/blob/master/BuildQualityChecks/en-US/CodeCoveragePolicy.md
* Set threshold to 79%
