### PR TITLE
Changing latest image tag to 6.8_latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 K2Bridge is a solution that enables Kibana to use [Azure Data Explorer](https://azure.microsoft.com/en-us/services/data-explorer/) (ADX, or codename Kusto) as its backend database.
 
+
+---
+# **Important note**
+
+## We are currently working on a new K2 version which will add support for visualization and for Kibana 7.10. To avoid a breaking change, we are changing the way we tag our images. 
+## The new images tags are: 6.8_latest and 7.10_latest, support Kibana 6.8 and Kibana 7.10 respectively.
+
+
+## _Action item:_ Use the provided helm chart to update the deployment with the new image tags.
+
 ---
 
 [![Build Status](https://dev.azure.com/csedevil/Kibana-kusto-bridge/_apis/build/status/K2bridge-Dev-CICD?branchName=master)](https://dev.azure.com/csedevil/Kibana-kusto-bridge/_build/latest?definitionId=169&branchName=master)

--- a/azure-pipelines.demo.yml
+++ b/azure-pipelines.demo.yml
@@ -18,6 +18,8 @@ variables:
   value: true
 - name: TELEMETRY_KEY
   value: "5d939046-15b2-448c-84be-2ecced5e9b1d"
+- name: k2Tag
+  value: 6.8_latest
 
 pool:
   vmImage: ubuntu-latest

--- a/azure-pipelines.dev.yml
+++ b/azure-pipelines.dev.yml
@@ -35,6 +35,8 @@ variables:
   value: false
 - name: TELEMETRY_KEY
   value: "00000000-0000-0000-0000-000000000000"
+- name: k2Tag
+  value: 6.8_latest
 
 pool:
   vmImage: ubuntu-latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 # The following variables can be optionally set for each pipeline run:
 # - RUN_FLAG_TERRAFORM: Set to 1 to have `terraform apply`. By default
 #   `terraform apply` only runs on the master branch.
-# - RUN_FLAG_PROMOTE: Set to 1 to promote the Docker image to `latest` tag if
+# - RUN_FLAG_PROMOTE: Set to 1 to promote the Docker image to `<supported_kibana_version>_latest` tag if
 #   tests are successful. By default this is only done on the master branch.
 # - RUN_SET_NAMESPACE: Set to a string to deploy to the given AKS namespace,
 #   and not delete the namespace after the build. By default the build deploys to
@@ -408,7 +408,7 @@ stages:
     steps:
 
     - task: AzureCLI@1
-      displayName: Tag Docker image as latest
+      displayName: Tag Docker image as 6.8_latest
       inputs:
         azureSubscription: $(ACR_PUSH_SERVICE_CONNECTION)
         scriptLocation: inlineScript
@@ -419,11 +419,11 @@ stages:
           docker pull "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION"
           docker tag \
             "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION" \
-            "$ACR_NAME.azurecr.io/k2bridge:latest"
-          docker push "$ACR_NAME.azurecr.io/k2bridge:latest"
+            "$ACR_NAME.azurecr.io/k2bridge:6.8_latest"
+          docker push "$ACR_NAME.azurecr.io/k2bridge:6.8_latest"
 
     - task: AzureCLI@1
-      displayName: Tag Docker image as latest for MCR
+      displayName: Tag Docker image as 6.8_latest for MCR
       inputs:
         azureSubscription: $(ACR_PUSH_SERVICE_CONNECTION)
         scriptLocation: inlineScript
@@ -434,8 +434,8 @@ stages:
           docker pull "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION"
           docker tag \
             "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION" \
-            "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:latest"
-          docker push "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:latest"
+            "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:6.8_latest"
+          docker push "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:6.8_latest"
           docker tag \
             "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION" \
             "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:$SEMANTIC_VERSION"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -408,7 +408,7 @@ stages:
     steps:
 
     - task: AzureCLI@1
-      displayName: Tag Docker image as 6.8_latest
+      displayName: Tag Docker image as $(k2Tag)
       inputs:
         azureSubscription: $(ACR_PUSH_SERVICE_CONNECTION)
         scriptLocation: inlineScript
@@ -419,11 +419,11 @@ stages:
           docker pull "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION"
           docker tag \
             "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION" \
-            "$ACR_NAME.azurecr.io/k2bridge:6.8_latest"
-          docker push "$ACR_NAME.azurecr.io/k2bridge:6.8_latest"
+            "$ACR_NAME.azurecr.io/k2bridge:$k2Tag"
+          docker push "$ACR_NAME.azurecr.io/k2bridge:$k2Tag"
 
     - task: AzureCLI@1
-      displayName: Tag Docker image as 6.8_latest for MCR
+      displayName: Tag Docker image as $(k2Tag) for MCR
       inputs:
         azureSubscription: $(ACR_PUSH_SERVICE_CONNECTION)
         scriptLocation: inlineScript
@@ -434,8 +434,8 @@ stages:
           docker pull "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION"
           docker tag \
             "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION" \
-            "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:6.8_latest"
-          docker push "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:6.8_latest"
+            "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:$k2Tag"
+          docker push "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:$k2Tag"
           docker tag \
             "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION" \
             "$ACR_MCR_NAME.azurecr.io/public/azuredataexplorer/k2bridge:$SEMANTIC_VERSION"

--- a/charts/k2bridge/Chart.yaml
+++ b/charts/k2bridge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A bridge connecting Kibana to Kusto (Azure Data Explorer) as its backend database
 name: k2bridge
-version: 0.1.0
+version: 0.2.0
 dependencies:
   - name: elasticsearch
     version: ~7.5.2

--- a/charts/k2bridge/values.yaml
+++ b/charts/k2bridge/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: mcr.microsoft.com/azuredataexplorer/k2bridge
-  tag: latest
+  tag: 6.8_latest
   pullPolicy: Always
 
 settings:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@
 | Replica Count                                   | replicaCount                    |                       2                      |     V    |                                                                     |
 | Private container registry                      | privateRegistry                 |                     NONE                     |     V    | Set the K8S secret to a private ACR                                 |
 | Repository                                      | image.repository                | mcr.microsoft.com/azuredataexplorer/k2bridge |     V    | ACR and image name                                                  |
-| Image tag                                       | image.tag                       |                    latest                    |     V    |                                                                     |
+| Image tag                                       | image.tag                       |                  6.8_latest                  |     V    |                                                                     |
 | Image pull policy                               | image.pullPolicy                |                    Always                    |     V    |                                                                     |
 | K2 listener address                             | settings.bridgeListenerAddress  |              http://k2bridge:80/             |     V    | Leave as default for most use cases                                 |
 | Internal ES instance address                    | settings.metadataElasticAddress |         http://k2bridgees-master:9200        |     V    | Leave as default for most use cases                                 |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,7 +65,7 @@ You need to be able to connect to your cluster from your machine.
         ```
 
         ```sh
-        helm install k2bridge charts/k2bridge -n k2bridge --set settings.adxClusterUrl="$ADX_URL" --set settings.adxDefaultDatabaseName="$ADX_DATABASE" --set settings.aadClientId="$ADX_CLIENT_ID" --set settings.aadClientSecret="$ADX_CLIENT_SECRET" --set settings.aadTenantId="$ADX_TENANT_ID" [--set image.tag=latest] [--set settings.collectTelemetry=$COLLECT_TELEMETRY]
+        helm install k2bridge charts/k2bridge -n k2bridge --set settings.adxClusterUrl="$ADX_URL" --set settings.adxDefaultDatabaseName="$ADX_DATABASE" --set settings.aadClientId="$ADX_CLIENT_ID" --set settings.aadClientSecret="$ADX_CLIENT_SECRET" --set settings.aadTenantId="$ADX_TENANT_ID" [--set image.tag=6.8_latest] [--set settings.collectTelemetry=$COLLECT_TELEMETRY]
         ```
 
         The complete set of configuration options can be found [here](./configuration.md).


### PR DESCRIPTION
The following changes are proposed:

* Changing latest image tag to 6.8_latest
* Following PR will change the new version to 7.10_latest
