### PR TITLE
Code Design Discussion

### DIFF
--- a/K2Bridge/ElasticQueryTranslator.cs
+++ b/K2Bridge/ElasticQueryTranslator.cs
@@ -114,7 +114,8 @@ namespace K2Bridge
                     sortFields,
                     docValueFields,
                     elasticSearchDsl.HighlightText,
-                    primaryAggregation);
+                    primaryAggregation,
+                    elasticSearchDsl.Aggregations);
 
                 if (elasticSearchDsl.Highlight != null)
                 {

--- a/K2Bridge/Models/QueryData.cs
+++ b/K2Bridge/Models/QueryData.cs
@@ -5,6 +5,7 @@
 namespace K2Bridge.Models
 {
     using System.Collections.Generic;
+    using K2Bridge.Models.Request.Aggregations;
 
     /// <summary>
     /// Represents the data needed to search for information in the database.
@@ -19,7 +20,7 @@ namespace K2Bridge.Models
         /// <param name="sortFields">Field names specified in query sort clause.</param>
         /// <param name="docValueFields">Field names specified in query docvalue_fields clause.</param>
         /// <param name="highlightText">What terms need to be highlighted in the results.</param>
-        public QueryData(string queryCommandText, string indexName, IList<string> sortFields = null, IList<string> docValueFields = null, Dictionary<string, string> highlightText = null, string primaryAggregation = null)
+        public QueryData(string queryCommandText, string indexName, IList<string> sortFields = null, IList<string> docValueFields = null, Dictionary<string, string> highlightText = null, string primaryAggregation = null, AggregationDictionary aggregations = null)
         {
             Ensure.IsNotNullOrEmpty(queryCommandText, nameof(queryCommandText), "Query string cannot be empty or null");
             Ensure.IsNotNullOrEmpty(indexName, nameof(indexName), "Index name string cannot be empty or null");
@@ -32,6 +33,7 @@ namespace K2Bridge.Models
             HighlightPreTag = string.Empty;
             HighlightPostTag = string.Empty;
             PrimaryAggregation = primaryAggregation;
+            Aggregations = aggregations;
         }
 
         /// <summary>
@@ -73,5 +75,10 @@ namespace K2Bridge.Models
         /// Gets or sets the primary aggregation.
         /// </summary>
         public string PrimaryAggregation { get; private set; }
+
+        /// <summary>
+        /// Gets or sets aggregation dictionnary.
+        /// </summary>
+        public AggregationDictionary Aggregations { get; private set; }
     }
 }

--- a/K2Bridge/Models/Request/Aggregations/Aggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Aggregation.cs
@@ -12,9 +12,9 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// Describes base aggregation class to visit.
     /// </summary>
-    internal abstract class Aggregation : KustoQLBase, IVisitable
+    public abstract class Aggregation : KustoQLBase, IVisitable
     {
-        public string Key { get; set; }
+        public string Key { get; internal set; }
 
         /// <inheritdoc/>
         public abstract void Accept(IVisitor visitor);

--- a/K2Bridge/Models/Request/Aggregations/AggregationContainer.cs
+++ b/K2Bridge/Models/Request/Aggregations/AggregationContainer.cs
@@ -14,17 +14,17 @@ namespace K2Bridge.Models.Request.Aggregations
     /// Describes aggregation container element in an Elasticsearch query.
     /// </summary>
     [JsonConverter(typeof(AggregationContainerConverter))]
-    internal class AggregationContainer : KustoQLBase, IVisitable
+    public class AggregationContainer : KustoQLBase, IVisitable
     {
         /// <summary>
         /// Gets or sets primary/most relevant aggregation.
         /// </summary>
-        public Aggregation PrimaryAggregation { get; set; }
+        public Aggregation PrimaryAggregation { get; internal set; }
 
         /// <summary>
         /// Gets or sets sub aggregations.
         /// </summary>
-        public AggregationDictionary SubAggregations { get; set; }
+        public AggregationDictionary SubAggregations { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Aggregations/AggregationDictionary.cs
+++ b/K2Bridge/Models/Request/Aggregations/AggregationDictionary.cs
@@ -9,7 +9,7 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// Describes aggregation dictionary element in an Elasticsearch query.
     /// </summary>
-    internal class AggregationDictionary : Dictionary<string, AggregationContainer>
+    public class AggregationDictionary : Dictionary<string, AggregationContainer>
     {
     }
 }

--- a/K2Bridge/Models/Request/Aggregations/Bucket/BucketAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Bucket/BucketAggregation.cs
@@ -7,8 +7,8 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// Bucket aggregations calculate metrics by creating buckets of documents.
     /// </summary>
-    internal abstract class BucketAggregation : Aggregation
+    public abstract class BucketAggregation : Aggregation
     {
-        public string Metric { get; set; } = "count()";
+        public string Metric { get; internal set; } = "count()";
     }
 }

--- a/K2Bridge/Models/Request/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
@@ -4,39 +4,38 @@
 
 namespace K2Bridge.Models.Request.Aggregations
 {
-    using K2Bridge.JsonConverters;
     using K2Bridge.Visitors;
     using Newtonsoft.Json;
 
     /// <summary>
     /// This multi-bucket aggregation is similar to the normal histogram, but it can only be used with date or date range values.
     /// </summary>
-    internal class DateHistogramAggregation : BucketAggregation
+    public class DateHistogramAggregation : BucketAggregation
     {
         /// <summary>
         /// Gets or sets the field to target.
         /// </summary>
         [JsonProperty("field")]
-        public string Field { get; set; }
+        public string Field { get; internal set; }
 
         /// <summary>
         /// Gets or sets the calendar interval to use when bucketing documents.
         /// </summary>
         [JsonProperty("calendar_interval")]
-        public string CalendarInterval { get; set; }
+        public string CalendarInterval { get; internal set; }
 
         /// <summary>
         /// Gets or sets the fixed interval to use when bucketing documents.
         /// </summary>
         [JsonProperty("fixed_interval")]
-        public string FixedInterval { get; set; }
+        public string FixedInterval { get; internal set; }
 
         /// <summary>
         /// Gets or sets the minimum number of documents that a bucket must contain to be returned in the response.
         /// The default is 0 meaning that buckets with no documents will be returned.
         /// </summary>
         [JsonProperty("min_doc_count")]
-        public int? MinimumDocumentCount { get; set; }
+        public int? MinimumDocumentCount { get; internal set; }
 
         /// <summary>
         /// Gets or sets the time zone.
@@ -45,7 +44,7 @@ namespace K2Bridge.Models.Request.Aggregations
         /// or as a timezone id, an identifier used in the TZ database like America/Los_Angeles.
         /// </summary>
         [JsonProperty("time_zone")]
-        public string TimeZone { get; set; }
+        public string TimeZone { get; internal set; }
 
         /// <inheritdoc/>
         public override void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Aggregations/Bucket/Terms/TermsAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Bucket/Terms/TermsAggregation.cs
@@ -12,23 +12,23 @@ namespace K2Bridge.Models.Request.Aggregations
     /// Bucket aggregation that creates one bucket per unique value in the designated field.
     // Default values are taken from Elasticserch API documentation.
     /// </summary>
-    internal class TermsAggregation : BucketAggregation
+    public class TermsAggregation : BucketAggregation
     {
         /// <summary>
         /// Gets or sets the field to aggregate.
         /// </summary>
         [JsonProperty("field")]
-        public string Field { get; set; }
+        public string Field { get; internal set; }
 
         [JsonProperty("order")]
         [JsonConverter(typeof(TermsOrderConverter))]
-        public TermsOrder Order { get; set; }
+        public TermsOrder Order { get; internal set; }
 
         /// <summary>
         /// Gets or sets the number of buckets to return.
         /// </summary>
         [JsonProperty("size")]
-        public int Size { get; set; } = 10;
+        public int Size { get; internal set; } = 10;
 
         /// <inheritdoc/>
         public override void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Aggregations/Bucket/Terms/TermsOrder.cs
+++ b/K2Bridge/Models/Request/Aggregations/Bucket/Terms/TermsOrder.cs
@@ -4,16 +4,16 @@
 
 namespace K2Bridge.Models.Request.Aggregations
 {
-    internal class TermsOrder
+    public class TermsOrder
     {
         /// <summary>
         /// Gets or sets the field name used to sort buckets.
         /// </summary>
-        public string SortField { get; set; } = "count_";
+        public string SortField { get; internal set; } = "count_";
 
         /// <summary>
         /// Gets or sets the ordering of the results.
         /// </summary>
-        public string SortOrder { get; set; } = "desc";
+        public string SortOrder { get; internal set; } = "desc";
     }
 }

--- a/K2Bridge/Models/Request/Aggregations/Metric/Average/AverageAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Metric/Average/AverageAggregation.cs
@@ -9,7 +9,7 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// A single-value metrics aggregation that computes the average of numeric values that are extracted from the aggregated documents.
     /// </summary>
-    internal class AverageAggregation : MetricAggregation
+    public class AverageAggregation : MetricAggregation
     {
         /// <inheritdoc/>
         public override void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Aggregations/Metric/Cardinality/CardinalityAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Metric/Cardinality/CardinalityAggregation.cs
@@ -9,7 +9,7 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// A single-value metrics aggregation that calculates an approximate count of distinct values.
     /// </summary>
-    internal class CardinalityAggregation : MetricAggregation
+    public class CardinalityAggregation : MetricAggregation
     {
         /// <inheritdoc/>
         public override void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Aggregations/Metric/Max/MaxAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Metric/Max/MaxAggregation.cs
@@ -9,7 +9,7 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// A single-value metrics aggregation that computes the max of numeric values that are extracted from the aggregated documents.
     /// </summary>
-    internal class MaxAggregation : MetricAggregation
+    public class MaxAggregation : MetricAggregation
     {
         /// <inheritdoc/>
         public override void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Aggregations/Metric/MetricAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Metric/MetricAggregation.cs
@@ -11,18 +11,18 @@ namespace K2Bridge.Models.Request.Aggregations
     /// that compute metrics based on values extracted from the documents that are being aggregated.
     /// The values are extracted from the fields of the document (using the field data).
     /// </summary>
-    internal abstract class MetricAggregation : Aggregation
+    public abstract class MetricAggregation : Aggregation
     {
         /// <summary>
         /// Gets or sets the field on which to aggregate.
         /// </summary>
         [JsonProperty("field")]
-        public string Field { get; set; }
+        public string Field { get; internal set; }
 
         /// <summary>
         /// Gets or sets the value to use when the aggregation finds a missing value in a document.
         /// </summary>
         [JsonProperty("missing")]
-        public double? Missing { get; set; }
+        public double? Missing { get; internal set; }
     }
 }

--- a/K2Bridge/Models/Request/Aggregations/Metric/Min/MinAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Metric/Min/MinAggregation.cs
@@ -9,7 +9,7 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// A single-value metrics aggregation that computes the min of numeric values that are extracted from the aggregated documents.
     /// </summary>
-    internal class MinAggregation : MetricAggregation
+    public class MinAggregation : MetricAggregation
     {
         /// <inheritdoc/>
         public override void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Aggregations/Metric/Percentile/PercentileAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Metric/Percentile/PercentileAggregation.cs
@@ -10,19 +10,19 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// A single-value metrics aggregation that computes the median of numeric values that are extracted from the aggregated documents.
     /// </summary>
-    internal class PercentileAggregation : MetricAggregation
+    public class PercentileAggregation : MetricAggregation
     {
         /// <summary>
         /// Gets or sets field percents for metric computation.
         /// </summary>
         [JsonProperty("percents")]
-        public double[] Percents { get; set; }
+        public double[] Percents { get; internal set; }
 
         /// <summary>
         /// Gets or sets field keyed for the Percentile Aggregation.
         /// </summary>
         [JsonProperty("keyed")]
-        public bool? Keyed { get; set; } = true;
+        public bool? Keyed { get; internal set; } = true;
 
         /// <inheritdoc/>
         public override void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Aggregations/Metric/Sum/SumAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Metric/Sum/SumAggregation.cs
@@ -11,7 +11,7 @@ namespace K2Bridge.Models.Request.Aggregations
     /// <summary>
     /// A single-value metrics aggregation that computes the sum of numeric values that are extracted from the aggregated documents.
     /// </summary>
-    internal class SumAggregation : MetricAggregation
+    public class SumAggregation : MetricAggregation
     {
         /// <inheritdoc/>
         public override void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/DocValueField.cs
+++ b/K2Bridge/Models/Request/DocValueField.cs
@@ -7,16 +7,16 @@ namespace K2Bridge.Models.Request
     /// <summary>
     /// Allows to return the doc value representation of a field for each hit.
     /// </summary>
-    internal class DocValueField
+    public class DocValueField
     {
         /// <summary>
         /// Gets or sets the field.
         /// </summary>
-        public string Field { get; set; }
+        public string Field { get; internal set; }
 
         /// <summary>
         /// Gets or sets the format.
         /// </summary>
-        public string Format { get; set; }
+        public string Format { get; internal set; }
     }
 }

--- a/K2Bridge/Models/Request/ElasticSearchDSL.cs
+++ b/K2Bridge/Models/Request/ElasticSearchDSL.cs
@@ -15,54 +15,54 @@ namespace K2Bridge.Models.Request
     /// the different properties of the elasticsearch query as deserialized from
     /// the json object sent from Kibana. This object will be sent for transformation.
     /// </summary>
-    internal class ElasticSearchDSL : KustoQLBase, IVisitable
+    public class ElasticSearchDSL : KustoQLBase, IVisitable
     {
         /// <summary>
         /// Gets or sets the query object.
         /// </summary>
         [JsonProperty("query")]
-        public Query Query { get; set; }
+        public Query Query { get; internal set; }
 
         /// <summary>
         /// Gets or sets the requested num of documents.
         /// </summary>
         [JsonProperty("size")]
-        public int Size { get; set; }
+        public int Size { get; internal set; }
 
         /// <summary>
         /// Gets or sets the query sorting value.
         /// </summary>
         [JsonProperty("sort")]
-        public List<SortClause> Sort { get; set; }
+        public List<SortClause> Sort { get; internal set; }
 
         /// <summary>
         /// Gets or sets the query aggregations value.
         /// </summary>
         [JsonProperty("aggs")]
-        public AggregationDictionary Aggregations { get; set; }
+        public AggregationDictionary Aggregations { get; internal set; }
 
         /// <summary>
         /// Gets or sets the doc value field.
         /// Which allows to return the doc value representation of a field for each hit.
         /// </summary>
         [JsonProperty("docvalue_fields")]
-        public List<DocValueField> DocValueFields { get; set; }
+        public List<DocValueField> DocValueFields { get; internal set; }
 
         /// <summary>
         /// Gets or sets the query highlight value.
         /// </summary>
         [JsonProperty("highlight")]
-        public Highlight Highlight { get; set; }
+        public Highlight Highlight { get; internal set; }
 
         /// <summary>
         /// Gets or sets the query highlight text value.
         /// </summary>
-        public Dictionary<string, string> HighlightText { get; set; }
+        public Dictionary<string, string> HighlightText { get; internal set; }
 
         /// <summary>
         /// Gets or sets the index name to query.
         /// </summary>
-        public string IndexName { get; set; }
+        public string IndexName { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/IQuery.cs
+++ b/K2Bridge/Models/Request/IQuery.cs
@@ -11,7 +11,7 @@ namespace K2Bridge.Models.Request
     /// An interface for query class.
     /// </summary>
     [JsonConverter(typeof(IQueryConverter))]
-    internal interface IQuery
+    public interface IQuery
     {
     }
 }

--- a/K2Bridge/Models/Request/KustoQLBase.cs
+++ b/K2Bridge/Models/Request/KustoQLBase.cs
@@ -7,7 +7,7 @@ namespace K2Bridge.Models.Request
     /// <summary>
     /// A base for all query related object that includes the translated query property.
     /// </summary>
-    internal abstract class KustoQLBase
+    public abstract class KustoQLBase
     {
         /// <summary>
         /// Gets or sets the translation of the query.

--- a/K2Bridge/Models/Request/Queries/BoolQuery.cs
+++ b/K2Bridge/Models/Request/Queries/BoolQuery.cs
@@ -11,33 +11,33 @@ namespace K2Bridge.Models.Request.Queries
     /// <summary>
     /// A query that matches documents by boolean combinations of other queries.
     /// </summary>
-    internal class BoolQuery : KustoQLBase, IVisitable, IQuery
+    public class BoolQuery : KustoQLBase, IVisitable, IQuery
     {
         /// <summary>
         /// Gets or sets Must value in bool query.
         /// </summary>
-        public IEnumerable<IQuery> Must { get; set; }
+        public IEnumerable<IQuery> Must { get; internal set; }
 
         /// <summary>
         /// Gets or sets MustNot value in bool query.
         /// </summary>
-        public IEnumerable<IQuery> MustNot { get; set; }
+        public IEnumerable<IQuery> MustNot { get; internal set; }
 
         /// <summary>
         /// Gets or sets Should value in bool query.
         /// </summary>
-        public IEnumerable<IQuery> Should { get; set; }
+        public IEnumerable<IQuery> Should { get; internal set; }
 
         /// <summary>
         /// Gets or sets ShouldNot value in bool query.
         /// </summary>
-        public IEnumerable<IQuery> ShouldNot { get; set; }
+        public IEnumerable<IQuery> ShouldNot { get; internal set; }
 
         /// <summary>
         /// Gets or sets the expressions for filtering documents.
         /// This applies before other search expressions in the query class (like Must).
         /// </summary>
-        public IEnumerable<IQuery> Filter { get; set; }
+        public IEnumerable<IQuery> Filter { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Queries/DocumentIds.cs
+++ b/K2Bridge/Models/Request/Queries/DocumentIds.cs
@@ -10,19 +10,19 @@ namespace K2Bridge.Models.Request.Queries
     /// <summary>
     /// A ViewSingleDocument query for a single doc id (represented by the _id column).
     /// </summary>
-    internal class DocumentIds : KustoQLBase, IVisitable
+    public class DocumentIds : KustoQLBase, IVisitable
     {
         /// <summary>
         /// Gets or sets the type of the required data.
         /// </summary>
         [JsonProperty("type")]
-        public string Type { get; set; }
+        public string Type { get; internal set; }
 
         /// <summary>
         /// Gets or sets the values for the required document (meaning: value of _id).
         /// </summary>
         [JsonProperty("values")]
-        public string[] Id { get; set; }
+        public string[] Id { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Queries/ExistsClause.cs
+++ b/K2Bridge/Models/Request/Queries/ExistsClause.cs
@@ -13,12 +13,12 @@ namespace K2Bridge.Models.Request.Queries
     /// Clause to retrieve documents that contain a value in a specified field.
     /// </summary>
     [JsonConverter(typeof(ExistsClauseConverter))]
-    internal class ExistsClause : KustoQLBase, ILeafClause, IVisitable
+    public class ExistsClause : KustoQLBase, ILeafClause, IVisitable
     {
         /// <summary>
         /// Gets or sets the exists FieldName.
         /// </summary>
-        public string FieldName { get; set; }
+        public string FieldName { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Queries/Highlight.cs
+++ b/K2Bridge/Models/Request/Queries/Highlight.cs
@@ -10,18 +10,18 @@ namespace K2Bridge.Models.Request.Queries
     /// <summary>
     /// Represents the highlighting tags for matching terms.
     /// </summary>
-    internal class Highlight
+    public class Highlight
     {
         /// <summary>
         /// Gets or sets pre tags.
         /// </summary>
         [JsonProperty("pre_tags")]
-        public List<string> PreTags { get; set; }
+        public List<string> PreTags { get; internal set; }
 
         /// <summary>
         /// Gets or sets post tags.
         /// </summary>
         [JsonProperty("post_tags")]
-        public List<string> PostTags { get; set; }
+        public List<string> PostTags { get; internal set; }
     }
 }

--- a/K2Bridge/Models/Request/Queries/ILeafClause.cs
+++ b/K2Bridge/Models/Request/Queries/ILeafClause.cs
@@ -12,8 +12,8 @@ namespace K2Bridge.Models.Request.Queries
     /// Leaf clause to visit.
     /// </summary>
     [JsonConverter(typeof(LeafClauseConverter))]
-    internal interface ILeafClause : IQuery
+    public interface ILeafClause : IQuery
     {
-        string KustoQL { get; set; }
+        string KustoQL { get; internal set; }
     }
 }

--- a/K2Bridge/Models/Request/Queries/MatchPhraseClause.cs
+++ b/K2Bridge/Models/Request/Queries/MatchPhraseClause.cs
@@ -13,17 +13,17 @@ namespace K2Bridge.Models.Request.Queries
     /// Match phrase is looking for exact match of a phrase and the field value.
     /// </summary>
     [JsonConverter(typeof(MatchPhraseClauseConverter))]
-    internal class MatchPhraseClause : KustoQLBase, IVisitable, ILeafClause
+    public class MatchPhraseClause : KustoQLBase, IVisitable, ILeafClause
     {
         /// <summary>
         /// Gets or sets the field to match.
         /// </summary>
-        public string FieldName { get; set; }
+        public string FieldName { get; internal set; }
 
         /// <summary>
         /// Gets or sets the matching phrase.
         /// </summary>
-        public object Phrase { get; set; }
+        public object Phrase { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Queries/Query.cs
+++ b/K2Bridge/Models/Request/Queries/Query.cs
@@ -11,19 +11,19 @@ namespace K2Bridge.Models.Request.Queries
     /// <summary>
     /// Full query to visit.
     /// </summary>
-    internal class Query : KustoQLBase, IVisitable
+    public class Query : KustoQLBase, IVisitable
     {
         /// <summary>
         /// Gets or sets bool query.
         /// </summary>
         [JsonProperty("bool")]
-        public BoolQuery Bool { get; set; }
+        public BoolQuery Bool { get; internal set; }
 
         /// <summary>
         /// Gets or sets the id with which to perform a ViewSingleDocument query.
         /// </summary>
         [JsonProperty("ids")]
-        public DocumentIds Ids { get; set; }
+        public DocumentIds Ids { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Queries/QueryStringClause.cs
+++ b/K2Bridge/Models/Request/Queries/QueryStringClause.cs
@@ -13,7 +13,7 @@ namespace K2Bridge.Models.Request.Queries
     /// Find documents based on string query.
     /// </summary>
     [JsonConverter(typeof(QueryStringClauseConverter))]
-    internal class QueryStringClause : KustoQLBase, ILeafClause, IVisitable
+    public class QueryStringClause : KustoQLBase, ILeafClause, IVisitable
     {
         /// <summary>
         /// Query subtype.
@@ -46,27 +46,27 @@ namespace K2Bridge.Models.Request.Queries
         /// These will be initially null when the object is created from a json payload,
         /// and will be populated by the visitor.
         /// </summary>
-        public Subtype? ParsedType { get; set; }
+        public Subtype? ParsedType { get; internal set; }
 
         /// <summary>
         /// Gets or sets field name to query.
         /// </summary>
-        public string ParsedFieldName { get; set; }
+        public string ParsedFieldName { get; internal set; }
 
         /// <summary>
         /// Gets or sets original properties of QueryStringClause.
         /// </summary>
-        public string Phrase { get; set; }
+        public string Phrase { get; internal set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether wildcard exists.
         /// </summary>
-        public bool Wildcard { get; set; }
+        public bool Wildcard { get; internal set; }
 
         /// <summary>
         /// Gets or sets default value.
         /// </summary>
-        public string Default { get; set; }
+        public string Default { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/Queries/RangeClause.cs
+++ b/K2Bridge/Models/Request/Queries/RangeClause.cs
@@ -13,17 +13,17 @@ namespace K2Bridge.Models.Request.Queries
     /// Find documents by field and a range.
     /// </summary>
     [JsonConverter(typeof(RangeClauseConverter))]
-    internal class RangeClause : KustoQLBase, ILeafClause, IVisitable
+    public class RangeClause : KustoQLBase, ILeafClause, IVisitable
     {
         /// <summary>
         /// Gets or sets the field name to query.
         /// </summary>
-        public string FieldName { get; set; }
+        public string FieldName { get; internal set; }
 
         /// <summary>
         /// Gets or sets GTE (greater than or equal to or equal) value.
         /// </summary>
-        public string GTEValue { get; set; }
+        public string GTEValue { get; internal set; }
 
         /// <summary>
         /// Gets or sets GT (greater than) value.
@@ -34,17 +34,17 @@ namespace K2Bridge.Models.Request.Queries
         /// <summary>
         /// Gets or sets LTE (less than or equal) value.
         /// </summary>
-        public string LTEValue { get; set; }
+        public string LTEValue { get; internal set; }
 
         /// <summary>
         /// Gets or sets LT (less than) value.
         /// </summary>
-        public string LTValue { get; set; }
+        public string LTValue { get; internal set; }
 
         /// <summary>
         /// Gets or sets Date format used to convert date values in the query.
         /// </summary>
-        public string Format { get; set; }
+        public string Format { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Models/Request/SortClause.cs
+++ b/K2Bridge/Models/Request/SortClause.cs
@@ -12,17 +12,17 @@ namespace K2Bridge.Models.Request
     /// Clause representing the requested order value in query.
     /// </summary>
     [JsonConverter(typeof(SortClauseConverter))]
-    internal class SortClause : KustoQLBase, IVisitable
+    public class SortClause : KustoQLBase, IVisitable
     {
         /// <summary>
         /// Gets or sets the field name to order by.
         /// </summary>
-        public string FieldName { get; set; }
+        public string FieldName { get; internal set; }
 
         /// <summary>
         /// Gets or sets the order value.
         /// </summary>
-        public string Order { get; set; }
+        public string Order { get; internal set; }
 
         /// <inheritdoc/>
         public void Accept(IVisitor visitor)

--- a/K2Bridge/Visitors/IVisitor.cs
+++ b/K2Bridge/Visitors/IVisitor.cs
@@ -11,7 +11,7 @@ namespace K2Bridge.Visitors
     /// <summary>
     /// IVisitor defines all the different visit methods overloads to handle all supported query types.
     /// </summary>
-    internal interface IVisitor
+    public interface IVisitor
     {
         /// <summary>
         /// Accepts a given visitable object and builds a Kusto query.


### PR DESCRIPTION
The following changes are proposed:

* Update access modifiers to pass aggregation dictionary in QueryData

Context: 
Some code portions could be simplified or removed if we were able to access the Aggregations dictionary info during the answer parsing.

For instance, in percentiles visitor, we add keyed and percentiles values to grab them back in the column name.
['A%percentile%25.0%50.0%99.0%False']=percentiles_array(fieldA, 25,50,99)']

The logic solution will be instead to only use the key and retrieve info needed in Aggregations info.

To do that, I would like to pass Aggregations dictionary in QueryData.

                var queryData = new QueryData(
                    elasticSearchDsl.KustoQL,
                    elasticSearchDsl.IndexName,
                    sortFields,
                    docValueFields,
                    elasticSearchDsl.HighlightText,
                    primaryAggregation);   <------ Add Aggregations dictionary in addition (or probably remove primaryAggregation as it's already contained in the dictionary).

But .. we come back to a previous conversation.
All model class are internal, it's not possible to add the aggregation dictionary except if I change the accessibility from internal to public.

So I suggest: 
- Update from internal to public all model class used in the request.
- Update from {get; set;} to {get; internal set:} all model class properties.










