### PR TITLE
[Bug-15963] - Wrapping field names with ['']

### DIFF
--- a/K2Bridge.Tests.End2End/QueryControllerErrorsTests.cs
+++ b/K2Bridge.Tests.End2End/QueryControllerErrorsTests.cs
@@ -19,7 +19,7 @@ namespace K2Bridge.Tests.End2End
                             ""root_cause"": [
                             {
                                 ""type"": ""SemanticException"",
-                                ""reason"": ""Semantic error: 'where' operator: Failed to resolve scalar expression named 'dayOfWe'. Query: 'let _data = database(""A"").kibana_sample_data_flights | where (timestamp >= unixtime_milliseconds_todatetime(1517954400000) and timestamp <= unixtime_milliseconds_todatetime(1518127199999)) and (dayOfWe has \""1\"");(_data | summarize count() by ['2'] = startofmonth(timestamp) | order by ['2'] asc | as aggs);(_data | count | as hitsTotal);(_data | order by timestamp desc | limit 500 | as hits)'"",
+                                ""reason"": ""Semantic error: 'where' operator: Failed to resolve scalar expression named 'dayOfWe'. Query: 'let _data = database(""A"").kibana_sample_data_flights | where (['timestamp'] >= unixtime_milliseconds_todatetime(1517954400000) and ['timestamp'] <= unixtime_milliseconds_todatetime(1518127199999)) and (dayOfWe has \""1\"");(_data | summarize count() by ['2'] = startofmonth(timestamp) | order by ['2'] asc | as aggs);(_data | count | as hitsTotal);(_data | order by timestamp desc | limit 500 | as hits)'"",
                                 ""index_uuid"": ""kibana_sample_data_flights"",
                                 ""index"": ""kibana_sample_data_flights""
                             }

--- a/K2Bridge.Tests.End2End/QueryControllerErrorsTests.cs
+++ b/K2Bridge.Tests.End2End/QueryControllerErrorsTests.cs
@@ -19,7 +19,7 @@ namespace K2Bridge.Tests.End2End
                             ""root_cause"": [
                             {
                                 ""type"": ""SemanticException"",
-                                ""reason"": ""Semantic error: 'where' operator: Failed to resolve scalar expression named 'dayOfWe'. Query: 'let _data = database(""A"").kibana_sample_data_flights | where (['timestamp'] >= unixtime_milliseconds_todatetime(1517954400000) and ['timestamp'] <= unixtime_milliseconds_todatetime(1518127199999)) and (dayOfWe has \""1\"");(_data | summarize count() by ['2'] = startofmonth(timestamp) | order by ['2'] asc | as aggs);(_data | count | as hitsTotal);(_data | order by timestamp desc | limit 500 | as hits)'"",
+                                ""reason"": ""Semantic error: 'where' operator: Failed to resolve scalar expression named 'dayOfWe'. Query: 'let _data = database(""A"").kibana_sample_data_flights | where (['timestamp'] >= unixtime_milliseconds_todatetime(1517954400000) and ['timestamp'] <= unixtime_milliseconds_todatetime(1518127199999)) and (dayOfWe has \""1\"");(_data | summarize count() by ['2'] = startofmonth(timestamp) | order by ['2'] asc | as aggs);(_data | count | as hitsTotal);(_data | order by ['timestamp'] desc | limit 500 | as hits)'"",
                                 ""index_uuid"": ""kibana_sample_data_flights"",
                                 ""index"": ""kibana_sample_data_flights""
                             }

--- a/K2Bridge.Tests.End2End/QueryControllerErrorsTests.cs
+++ b/K2Bridge.Tests.End2End/QueryControllerErrorsTests.cs
@@ -19,7 +19,7 @@ namespace K2Bridge.Tests.End2End
                             ""root_cause"": [
                             {
                                 ""type"": ""SemanticException"",
-                                ""reason"": ""Semantic error: 'where' operator: Failed to resolve scalar expression named 'dayOfWe'. Query: 'let _data = database(""A"").kibana_sample_data_flights | where (['timestamp'] >= unixtime_milliseconds_todatetime(1517954400000) and ['timestamp'] <= unixtime_milliseconds_todatetime(1518127199999)) and (dayOfWe has \""1\"");(_data | summarize count() by ['2'] = startofmonth(timestamp) | order by ['2'] asc | as aggs);(_data | count | as hitsTotal);(_data | order by ['timestamp'] desc | limit 500 | as hits)'"",
+                                ""reason"": ""Semantic error: 'where' operator: Failed to resolve scalar expression named 'dayOfWe'. Query: 'let _data = database(""A"").kibana_sample_data_flights | where (['timestamp'] >= unixtime_milliseconds_todatetime(1517954400000) and ['timestamp'] <= unixtime_milliseconds_todatetime(1518127199999)) and (dayOfWe has \""1\"");(_data | summarize count() by ['2'] = startofmonth(['timestamp']) | order by ['2'] asc | as aggs);(_data | count | as hitsTotal);(_data | order by ['timestamp'] desc | limit 500 | as hits)'"",
                                 ""index_uuid"": ""kibana_sample_data_flights"",
                                 ""index"": ""kibana_sample_data_flights""
                             }
@@ -60,8 +60,8 @@ namespace K2Bridge.Tests.End2End
             expectedJsonString = databasePattern.Replace(expectedJsonString, replacement);
             assertString = databasePattern.Replace(assertString, replacement);
             Assert.AreEqual(
-                assertString,
                 expectedJsonString,
+                assertString,
                 $"json {assertString} did not match expected {expectedJsonString}");
         }
     }

--- a/K2Bridge.Tests.UnitTests/Visitors/DateHistogramAggregationVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/DateHistogramAggregationVisitorTests.cs
@@ -27,12 +27,12 @@ namespace UnitTests.K2Bridge.Visitors
             return histogramAggregation.KustoQL;
         }
 
-        [TestCase("w", ExpectedResult = "_data | summarize metric by ['key'] = startofweek(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfWeekInterval_ReturnsValidResponse")]
-        [TestCase("week", ExpectedResult = "_data | summarize metric by ['key'] = startofweek(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfWeekInterval_ReturnsValidResponse")]
-        [TestCase("y", ExpectedResult = "_data | summarize metric by ['key'] = startofyear(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfYearInterval_ReturnsValidResponse")]
-        [TestCase("year", ExpectedResult = "_data | summarize metric by ['key'] = startofyear(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfYearInterval_ReturnsValidResponse")]
-        [TestCase("M", ExpectedResult = "_data | summarize metric by ['key'] = startofmonth(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfMonthInterval_ReturnsValidResponse")]
-        [TestCase("month", ExpectedResult = "_data | summarize metric by ['key'] = startofmonth(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfMonthInterval_ReturnsValidResponse")]
+        [TestCase("w", ExpectedResult = "_data | summarize metric by ['key'] = startofweek(['field'])\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfWeekInterval_ReturnsValidResponse")]
+        [TestCase("week", ExpectedResult = "_data | summarize metric by ['key'] = startofweek(['field'])\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfWeekInterval_ReturnsValidResponse")]
+        [TestCase("y", ExpectedResult = "_data | summarize metric by ['key'] = startofyear(['field'])\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfYearInterval_ReturnsValidResponse")]
+        [TestCase("year", ExpectedResult = "_data | summarize metric by ['key'] = startofyear(['field'])\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfYearInterval_ReturnsValidResponse")]
+        [TestCase("M", ExpectedResult = "_data | summarize metric by ['key'] = startofmonth(['field'])\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfMonthInterval_ReturnsValidResponse")]
+        [TestCase("month", ExpectedResult = "_data | summarize metric by ['key'] = startofmonth(['field'])\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfMonthInterval_ReturnsValidResponse")]
         [TestCase("z", ExpectedResult = "_data | summarize metric by ['key'] = bin(['field'], z)\n| order by ['key'] asc")]
         public string DateHistogramVisit_WithAggregation_ReturnsValidResponse(string interval)
         {

--- a/K2Bridge.Tests.UnitTests/Visitors/DateHistogramAggregationVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/DateHistogramAggregationVisitorTests.cs
@@ -33,7 +33,7 @@ namespace UnitTests.K2Bridge.Visitors
         [TestCase("year", ExpectedResult = "_data | summarize metric by ['key'] = startofyear(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfYearInterval_ReturnsValidResponse")]
         [TestCase("M", ExpectedResult = "_data | summarize metric by ['key'] = startofmonth(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfMonthInterval_ReturnsValidResponse")]
         [TestCase("month", ExpectedResult = "_data | summarize metric by ['key'] = startofmonth(field)\n| order by ['key'] asc", TestName = "DateHistogramVisit_WithStartOfMonthInterval_ReturnsValidResponse")]
-        [TestCase("z", ExpectedResult = "_data | summarize metric by ['key'] = bin(field, z)\n| order by ['key'] asc")]
+        [TestCase("z", ExpectedResult = "_data | summarize metric by ['key'] = bin(['field'], z)\n| order by ['key'] asc")]
         public string DateHistogramVisit_WithAggregation_ReturnsValidResponse(string interval)
         {
             var histogramAggregation = new DateHistogramAggregation()

--- a/K2Bridge.Tests.UnitTests/Visitors/ElasticSearchDSLVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/ElasticSearchDSLVisitorTests.cs
@@ -188,7 +188,7 @@ namespace UnitTests.K2Bridge.Visitors
 
             CreateVisitorAndVisit(dsl);
 
-            Assert.True(dsl.KustoQL.Contains("_data | summarize count() by ['2'] = bin(timestamp, 1m)\n", StringComparison.OrdinalIgnoreCase));
+            Assert.True(dsl.KustoQL.Contains("_data | summarize count() by ['2'] = bin(['timestamp'], 1m)\n", StringComparison.OrdinalIgnoreCase));
         }
 
         [Test]
@@ -215,7 +215,7 @@ namespace UnitTests.K2Bridge.Visitors
 
             CreateVisitorAndVisit(dsl);
 
-            Assert.True(dsl.KustoQL.Contains("\n(_data | order by timestamp asc | limit 17", StringComparison.OrdinalIgnoreCase));
+            Assert.True(dsl.KustoQL.Contains("\n(_data | order by ['timestamp'] asc | limit 17", StringComparison.OrdinalIgnoreCase));
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace UnitTests.K2Bridge.Visitors
 
             CreateVisitorAndVisit(dsl);
 
-            Assert.False(dsl.KustoQL.Contains("\n(_data | order by timestamp asc", StringComparison.OrdinalIgnoreCase));
+            Assert.False(dsl.KustoQL.Contains("\n(_data | order by ['timestamp'] asc", StringComparison.OrdinalIgnoreCase));
         }
 
         [Test]

--- a/K2Bridge.Tests.UnitTests/Visitors/LuceneNet/LuceneRangeVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/LuceneNet/LuceneRangeVisitorTests.cs
@@ -39,7 +39,7 @@ namespace UnitTests.K2Bridge.Visitors.LuceneNet
                 Throws.TypeOf<IllegalClauseException>());
         }
 
-        [TestCase(ExpectedResult = "days >= 2 and days <= 6")]
+        [TestCase(ExpectedResult = "['days'] >= 2 and ['days'] <= 6")]
         public string Visit_WithValidRangeQuery_ReturnsValidResponse()
         {
             var rangeQuery = new LuceneRangeQuery

--- a/K2Bridge.Tests.UnitTests/Visitors/MatchPhraseVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/MatchPhraseVisitorTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests.K2Bridge.Visitors
     [TestFixture]
     public class MatchPhraseVisitorTests
     {
-        [TestCase(ExpectedResult = "MyField == \"MyPhrase\"")]
+        [TestCase(ExpectedResult = "['MyField'] == \"MyPhrase\"")]
         public string MatchPhraseVisit_WithValidClause_ReturnsEquals()
         {
             var matchPhraseClause = CreateMatchPhraseClause("MyField", "MyPhrase");
@@ -20,7 +20,7 @@ namespace UnitTests.K2Bridge.Visitors
             return VisitQuery(matchPhraseClause);
         }
 
-        [TestCase(ExpectedResult = "MyField == 3")]
+        [TestCase(ExpectedResult = "['MyField'] == 3")]
         public string MatchPhraseVisit_WithValidIntClause_ReturnsEquals()
         {
             var matchPhraseClause = CreateMatchPhraseClause("MyField", 3);
@@ -28,7 +28,7 @@ namespace UnitTests.K2Bridge.Visitors
             return VisitQuery(matchPhraseClause);
         }
 
-        [TestCase(ExpectedResult = "MyField == 3.5")]
+        [TestCase(ExpectedResult = "['MyField'] == 3.5")]
         public string MatchPhraseVisit_WithValidDoubleClause_ReturnsEquals()
         {
             var matchPhraseClause = CreateMatchPhraseClause("MyField", 3.5);
@@ -44,7 +44,7 @@ namespace UnitTests.K2Bridge.Visitors
             return VisitQuery(matchPhraseClause);
         }
 
-        [TestCase(ExpectedResult = "MyField == \"\"")]
+        [TestCase(ExpectedResult = "['MyField'] == \"\"")]
         public string MatchPhraseVisit_WithoutClause_ReturnsEqualsEmpty()
         {
             var matchPhraseClause = CreateMatchPhraseClause("MyField", null);

--- a/K2Bridge.Tests.UnitTests/Visitors/MatchPhraseVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/MatchPhraseVisitorTests.cs
@@ -36,7 +36,7 @@ namespace UnitTests.K2Bridge.Visitors
             return VisitQuery(matchPhraseClause);
         }
 
-        [TestCase(ExpectedResult = "MyField == todatetime(\"2017-01-02T13:45:23.1330000Z\")")]
+        [TestCase(ExpectedResult = "['MyField'] == todatetime(\"2017-01-02T13:45:23.1330000Z\")")]
         public string MatchPhraseVisit_WithValidDateClause_ReturnsEquals()
         {
             var matchPhraseClause = CreateMatchPhraseClause("MyField", new DateTime(2017, 1, 2, 13, 45, 23, 133, DateTimeKind.Utc));

--- a/K2Bridge.Tests.UnitTests/Visitors/ParseElasticToKqlTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/ParseElasticToKqlTests.cs
@@ -302,7 +302,7 @@ namespace UnitTests.K2Bridge.Visitors
 
         [TestCase(
             QueryTimestampRangeSingle,
-            ExpectedResult = "where (timestamp >= unixtime_milliseconds_todatetime(0) and timestamp <= unixtime_milliseconds_todatetime(10))",
+            ExpectedResult = "where (['timestamp'] >= unixtime_milliseconds_todatetime(0) and ['timestamp'] <= unixtime_milliseconds_todatetime(10))",
             TestName = "QueryAccept_WithTimestamp_ReturnsExpectedResult")]
         [TestCase(
             QueryBetweenRangeSingle,
@@ -335,7 +335,7 @@ namespace UnitTests.K2Bridge.Visitors
 
         [TestCase(
             CombinedQuery,
-            ExpectedResult = "where (* has \"TEST_RESULT\") and (TEST_FIELD == \"TEST_RESULT_2\") and (TEST_FIELD_2 == \"TEST_RESULT_3\") and (timestamp >= unixtime_milliseconds_todatetime(0) and timestamp <= unixtime_milliseconds_todatetime(10))",
+            ExpectedResult = "where (* has \"TEST_RESULT\") and (TEST_FIELD == \"TEST_RESULT_2\") and (TEST_FIELD_2 == \"TEST_RESULT_3\") and (['timestamp'] >= unixtime_milliseconds_todatetime(0) and ['timestamp'] <= unixtime_milliseconds_todatetime(10))",
             TestName = "QueryAccept_WithCombinedQuery_ReturnsExpectedResult")]
         [TestCase(
             NotQueryStringClause,

--- a/K2Bridge.Tests.UnitTests/Visitors/ParseElasticToKqlTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/ParseElasticToKqlTests.cs
@@ -306,7 +306,7 @@ namespace UnitTests.K2Bridge.Visitors
             TestName = "QueryAccept_WithTimestamp_ReturnsExpectedResult")]
         [TestCase(
             QueryBetweenRangeSingle,
-            ExpectedResult = "where (TEST_FIELD >= 0 and TEST_FIELD < 10)",
+            ExpectedResult = "where (['TEST_FIELD'] >= 0 and ['TEST_FIELD'] < 10)",
             TestName = "QueryAccept_WithBetweenRange_ReturnsExpectedResult")]
         public string TestRangeQueries(string queryString)
         {

--- a/K2Bridge.Tests.UnitTests/Visitors/ParseElasticToKqlTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/ParseElasticToKqlTests.cs
@@ -274,11 +274,11 @@ namespace UnitTests.K2Bridge.Visitors
 
         [TestCase(
             QueryMatchPhraseSingle,
-            ExpectedResult = "where (TEST_FIELD == \"TEST_RESULT\")",
+            ExpectedResult = "where (['TEST_FIELD'] == \"TEST_RESULT\")",
             TestName = "QueryAccept_WithSingleMatchPhrase_ReturnsExpectedResult")]
         [TestCase(
             QueryMatchPhraseMulti,
-            ExpectedResult = "where (TEST_FIELD == \"TEST_RESULT\") and (TEST_FIELD_2 == \"TEST_RESULT_2\")",
+            ExpectedResult = "where (['TEST_FIELD'] == \"TEST_RESULT\") and (['TEST_FIELD_2'] == \"TEST_RESULT_2\")",
             TestName = "QueryAccept_WithMultiMatchPhrase_ReturnsExpectedResult")]
         public string TestMatchPhraseQueries(string queryString)
         {
@@ -335,11 +335,11 @@ namespace UnitTests.K2Bridge.Visitors
 
         [TestCase(
             CombinedQuery,
-            ExpectedResult = "where (* has \"TEST_RESULT\") and (TEST_FIELD == \"TEST_RESULT_2\") and (TEST_FIELD_2 == \"TEST_RESULT_3\") and (['timestamp'] >= unixtime_milliseconds_todatetime(0) and ['timestamp'] <= unixtime_milliseconds_todatetime(10))",
+            ExpectedResult = "where (* has \"TEST_RESULT\") and (['TEST_FIELD'] == \"TEST_RESULT_2\") and (['TEST_FIELD_2'] == \"TEST_RESULT_3\") and (['timestamp'] >= unixtime_milliseconds_todatetime(0) and ['timestamp'] <= unixtime_milliseconds_todatetime(10))",
             TestName = "QueryAccept_WithCombinedQuery_ReturnsExpectedResult")]
         [TestCase(
             NotQueryStringClause,
-            ExpectedResult = "where (* has \"TEST_RESULT\") and (TEST_FIELD != \"TEST_RESULT_2\")",
+            ExpectedResult = "where (* has \"TEST_RESULT\") and (['TEST_FIELD'] != \"TEST_RESULT_2\")",
             TestName = "QueryAccept_WithNotString_ReturnsExpectedResult")]
         public string TestCombinedQueries(string queryString)
         {

--- a/K2Bridge.Tests.UnitTests/Visitors/RangeClauseVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/RangeClauseVisitorTests.cs
@@ -22,42 +22,42 @@ namespace UnitTests.K2Bridge.Visitors
     {
         // Numeric RangeClause Query Tests
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > 0 and MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > 0 and MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= 0 and MyField < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= 0 and MyField <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "['MyField'] < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "['MyField'] <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] > 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] > 0 and ['MyField'] < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] > 0 and ['MyField'] <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] >= 0", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] >= 0 and ['MyField'] < 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] >= 0 and ['MyField'] <= 10", TestName = "Visit_WithValidRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidRangeClauseVisitNumberBetweenTwoInts(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateRangeClause("0", "10", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > 0 and MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > 0 and MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= 0 and MyField < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= 0 and MyField <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "['MyField'] < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "['MyField'] <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] > 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] > 0 and ['MyField'] < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] > 0 and ['MyField'] <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] >= 0", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] >= 0 and ['MyField'] < 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] >= 0 and ['MyField'] <= 10.10", TestName = "Visit_WithValidRangeBetweenIntAndDecimal_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidRangeClauseVisitNumberBetweenIntAndDecimal(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateRangeClause("0", "10.10", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > 10.10 and MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > 10.10 and MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= 10.10 and MyField < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= 10.10 and MyField <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "['MyField'] < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "['MyField'] <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] > 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] > 10.10 and ['MyField'] < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] > 10.10 and ['MyField'] <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] >= 10.10", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] >= 10.10 and ['MyField'] < 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] >= 10.10 and ['MyField'] <= 20.20", TestName = "Visit_WithValidRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidRangeClauseVisitNumberBetweenTwoDecimals(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateRangeClause("10.10", "20.20", minRange, maxRange));
@@ -65,56 +65,56 @@ namespace UnitTests.K2Bridge.Visitors
 
         // Time RangeClause Query Tests
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "['MyField'] < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "['MyField'] <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(0) and ['MyField'] < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(0) and ['MyField'] <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(0) and ['MyField'] < unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(0) and ['MyField'] <= unixtime_milliseconds_todatetime(10)", TestName = "Visit_WithValidRangeBetweenInts_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidTimeRangeClauseVisitNumberBetweenTwoInts(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateTimeRangeClause("0", "10", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(0) and MyField <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "['MyField'] < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "['MyField'] <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(0) and ['MyField'] < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(0) and ['MyField'] <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(0)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(0) and ['MyField'] < unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(0) and ['MyField'] <= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenNumbers_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidTimeRangeClauseVisitNumberBetweenIntAndDecimal(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateTimeRangeClause("0", "10.10", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10) and MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= unixtime_milliseconds_todatetime(10.10) and MyField <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "['MyField'] < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "['MyField'] <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(10.10) and ['MyField'] < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] > unixtime_milliseconds_todatetime(10.10) and ['MyField'] <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(10.10)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(10.10) and ['MyField'] < unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] >= unixtime_milliseconds_todatetime(10.10) and ['MyField'] <= unixtime_milliseconds_todatetime(20.20)", TestName = "Visit_WithValidTimeRangeBetweenDecimals_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidTimeRangeClauseVisitNumberBetweenTwoDecimals(RangeType minRange, RangeType maxRange)
         {
             return RangeClauseToKQL(CreateTimeRangeClause("10.10", "20.20", minRange, maxRange));
         }
 
         [TestCase(RangeType.Wildcard, RangeType.Wildcard, ExpectedResult = "", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxWildcard")]
-        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
-        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
-        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
-        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\") and MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
-        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "MyField > todatetime(\"2020-01-01T00:00:00.0000000\") and MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
-        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
-        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\") and MyField < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
-        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "MyField >= todatetime(\"2020-01-01T00:00:00.0000000\") and MyField <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
+        [TestCase(RangeType.Wildcard, RangeType.Exclusive, ExpectedResult = "['MyField'] < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxOpen")]
+        [TestCase(RangeType.Wildcard, RangeType.Inclusive, ExpectedResult = "['MyField'] <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinWildcardAndMaxClosed")]
+        [TestCase(RangeType.Exclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] > todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxWildcard")]
+        [TestCase(RangeType.Exclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] > todatetime(\"2020-01-01T00:00:00.0000000\") and ['MyField'] < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxOpen")]
+        [TestCase(RangeType.Exclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] > todatetime(\"2020-01-01T00:00:00.0000000\") and ['MyField'] <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinOpenAndMaxClosed")]
+        [TestCase(RangeType.Inclusive, RangeType.Wildcard, ExpectedResult = "['MyField'] >= todatetime(\"2020-01-01T00:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxWildcard")]
+        [TestCase(RangeType.Inclusive, RangeType.Exclusive, ExpectedResult = "['MyField'] >= todatetime(\"2020-01-01T00:00:00.0000000\") and ['MyField'] < todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxOpen")]
+        [TestCase(RangeType.Inclusive, RangeType.Inclusive, ExpectedResult = "['MyField'] >= todatetime(\"2020-01-01T00:00:00.0000000\") and ['MyField'] <= todatetime(\"2020-02-22T10:00:00.0000000\")", TestName = "Visit_ValidDateRange_ReturnsValidResponse_WhenMinClosedAndMaxClosed")]
         public string TestValidDateRange_ReturnsValidResponse(RangeType minRange, RangeType maxRange)
         {
             return DateRangeClauseToKQL(CreateDateRangeClause("2020-01-01 00:00", "2020-02-22 10:00", minRange, maxRange));

--- a/K2Bridge.Tests.UnitTests/Visitors/RangeVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/RangeVisitorTests.cs
@@ -13,7 +13,7 @@ namespace UnitTests.K2Bridge.Visitors
     public class RangeVisitorTests
     {
         [TestCase(
-            ExpectedResult = "myField >= 3 and myField < 5",
+            ExpectedResult = "['MyField'] >= 3 and ['MyField'] < 5",
             TestName = "Visit_WithBasicInput_ReturnsValidResponse")]
         public string TestBasicRangeVisitor()
         {
@@ -24,7 +24,7 @@ namespace UnitTests.K2Bridge.Visitors
 
         [TestCase(
             ExpectedResult =
-            "myField >= unixtime_milliseconds_todatetime(1212121121) and myField <= unixtime_milliseconds_todatetime(2121212121)",
+            "['MyField'] >= unixtime_milliseconds_todatetime(1212121121) and ['MyField'] <= unixtime_milliseconds_todatetime(2121212121)",
             TestName = "Visit_WithEpochInput_ReturnsValidResponse")]
         public string TestEpochBasicRangeVisitor()
         {

--- a/K2Bridge.Tests.UnitTests/Visitors/RangeVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/RangeVisitorTests.cs
@@ -13,7 +13,7 @@ namespace UnitTests.K2Bridge.Visitors
     public class RangeVisitorTests
     {
         [TestCase(
-            ExpectedResult = "['MyField'] >= 3 and ['MyField'] < 5",
+            ExpectedResult = "['myField'] >= 3 and ['myField'] < 5",
             TestName = "Visit_WithBasicInput_ReturnsValidResponse")]
         public string TestBasicRangeVisitor()
         {
@@ -24,7 +24,7 @@ namespace UnitTests.K2Bridge.Visitors
 
         [TestCase(
             ExpectedResult =
-            "['MyField'] >= unixtime_milliseconds_todatetime(1212121121) and ['MyField'] <= unixtime_milliseconds_todatetime(2121212121)",
+            "['myField'] >= unixtime_milliseconds_todatetime(1212121121) and ['myField'] <= unixtime_milliseconds_todatetime(2121212121)",
             TestName = "Visit_WithEpochInput_ReturnsValidResponse")]
         public string TestEpochBasicRangeVisitor()
         {

--- a/K2Bridge.Tests.UnitTests/Visitors/SortClauseVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/SortClauseVisitorTests.cs
@@ -25,7 +25,7 @@ namespace UnitTests.K2Bridge.Visitors
         }
 
         [TestCase(
-            ExpectedResult = "wibble asc",
+            ExpectedResult = "['wibble'] asc",
             TestName = "Visit_WithValidInput_ReturnsExpectedResult")]
         public string GeneratesClauseQuery()
         {

--- a/K2Bridge.Tests.UnitTests/Visitors/SortVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/SortVisitorTests.cs
@@ -12,7 +12,7 @@ namespace UnitTests.K2Bridge.Visitors
     public class SortVisitorTests
     {
         [TestCase(
-            ExpectedResult = "myFieldName ASC",
+            ExpectedResult = "['myFieldName'] ASC",
             TestName = "Visit_WithBasicInput_ReturnsExpectedResult")]
         public string TestBasicSortVisitor()
         {

--- a/K2Bridge/Visitors/DateHistogramVisitor.cs
+++ b/K2Bridge/Visitors/DateHistogramVisitor.cs
@@ -31,12 +31,12 @@ namespace K2Bridge.Visitors
                 var period = interval[^1];
                 dateHistogramAggregation.KustoQL += period switch
                 {
-                    'w' => $"{KustoQLOperators.StartOfWeek}({dateHistogramAggregation.Field})",
-                    'M' => $"{KustoQLOperators.StartOfMonth}({dateHistogramAggregation.Field})",
-                    'y' => $"{KustoQLOperators.StartOfYear}({dateHistogramAggregation.Field})",
-                    _ when interval.Contains("week", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfWeek}({dateHistogramAggregation.Field})",
-                    _ when interval.Contains("month", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfMonth}({dateHistogramAggregation.Field})",
-                    _ when interval.Contains("year", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfYear}({dateHistogramAggregation.Field})",
+                    'w' => $"{KustoQLOperators.StartOfWeek}(['{dateHistogramAggregation.Field}'])",
+                    'M' => $"{KustoQLOperators.StartOfMonth}(['{dateHistogramAggregation.Field}'])",
+                    'y' => $"{KustoQLOperators.StartOfYear}(['{dateHistogramAggregation.Field}'])",
+                    _ when interval.Contains("week", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfWeek}(['{dateHistogramAggregation.Field}'])",
+                    _ when interval.Contains("month", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfMonth}(['{dateHistogramAggregation.Field}'])",
+                    _ when interval.Contains("year", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfYear}(['{dateHistogramAggregation.Field}'])",
                     _ => $"bin(['{dateHistogramAggregation.Field}'], {interval})",
                 };
             }

--- a/K2Bridge/Visitors/DateHistogramVisitor.cs
+++ b/K2Bridge/Visitors/DateHistogramVisitor.cs
@@ -37,7 +37,7 @@ namespace K2Bridge.Visitors
                     _ when interval.Contains("week", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfWeek}({dateHistogramAggregation.Field})",
                     _ when interval.Contains("month", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfMonth}({dateHistogramAggregation.Field})",
                     _ when interval.Contains("year", System.StringComparison.OrdinalIgnoreCase) => $"{KustoQLOperators.StartOfYear}({dateHistogramAggregation.Field})",
-                    _ => $"bin({dateHistogramAggregation.Field}, {interval})",
+                    _ => $"bin(['{dateHistogramAggregation.Field}'], {interval})",
                 };
             }
             else

--- a/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
+++ b/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
@@ -16,8 +16,8 @@ namespace K2Bridge.Visitors
     {
         // The following regexes look for the '?' or '*' chars which are
         // not followed by an escape character
-        private static readonly Regex SingleCharPattern = new (@"(?<!\\)\?");
-        private static readonly Regex MultiCharPattern = new (@"(?<!\\)\*");
+        private static readonly Regex SingleCharPattern = new(@"(?<!\\)\?");
+        private static readonly Regex MultiCharPattern = new(@"(?<!\\)\*");
 
         /// <inheritdoc/>
         public void Visit(MatchPhraseClause matchPhraseClause)
@@ -36,11 +36,11 @@ namespace K2Bridge.Visitors
                     object o => $"\"{matchPhraseClause.Phrase.ToString().EscapeSlashes()}\"",
                 };
 
-                matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} {parsedPhrase}";
+                matchPhraseClause.KustoQL = $"['{matchPhraseClause.FieldName}'] {KustoQLOperators.Equal} {parsedPhrase}";
                 return;
             }
 
-            matchPhraseClause.KustoQL = $"{matchPhraseClause.FieldName} {KustoQLOperators.Equal} \"\"";
+            matchPhraseClause.KustoQL = $"['{matchPhraseClause.FieldName}'] {KustoQLOperators.Equal} \"\"";
         }
     }
 }

--- a/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
+++ b/K2Bridge/Visitors/MatchPhraseQueryVisitor.cs
@@ -16,8 +16,8 @@ namespace K2Bridge.Visitors
     {
         // The following regexes look for the '?' or '*' chars which are
         // not followed by an escape character
-        private static readonly Regex SingleCharPattern = new(@"(?<!\\)\?");
-        private static readonly Regex MultiCharPattern = new(@"(?<!\\)\*");
+        private static readonly Regex SingleCharPattern = new (@"(?<!\\)\?");
+        private static readonly Regex MultiCharPattern = new (@"(?<!\\)\*");
 
         /// <inheritdoc/>
         public void Visit(MatchPhraseClause matchPhraseClause)

--- a/K2Bridge/Visitors/RangeClauseVisitor.cs
+++ b/K2Bridge/Visitors/RangeClauseVisitor.cs
@@ -74,8 +74,8 @@ namespace K2Bridge.Visitors
                 _ => throw new Exception("Invalid range clause."),
             };
 
-            var gtQuery = gtOperator != null ? $"{rangeClause.FieldName} {gtOperator} {gtValue}" : null;
-            var ltQuery = ltOperator != null ? $"{rangeClause.FieldName} {ltOperator} {ltValue}" : null;
+            var gtQuery = gtOperator != null ? $"['{rangeClause.FieldName}'] {gtOperator} {gtValue}" : null;
+            var ltQuery = ltOperator != null ? $"['{rangeClause.FieldName}'] {ltOperator} {ltValue}" : null;
             rangeClause.KustoQL = (gtQuery, ltQuery) switch
             {
                 (null, null) => string.Empty,

--- a/K2Bridge/Visitors/SortClauseVisitor.cs
+++ b/K2Bridge/Visitors/SortClauseVisitor.cs
@@ -27,7 +27,7 @@ namespace K2Bridge.Visitors
             {
                 EnsureClause.StringIsNotNullOrEmpty(sortClause.Order, nameof(sortClause.Order));
 
-                sortClause.KustoQL = $"{sortClause.FieldName} {sortClause.Order}";
+                sortClause.KustoQL = $"['{sortClause.FieldName}'] {sortClause.Order}";
             }
         }
     }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -312,7 +312,7 @@ stages:
 
 - stage: integration_tests
   displayName: Integration Tests
-  condition: not(variables['IS_DEMO_PIPELINE'])
+  condition: and(succeeded(), not(variables['IS_DEMO_PIPELINE']))
   dependsOn:
   - build
   - terraform


### PR DESCRIPTION
In some cases, the field name was not wrapped with [' ']. 
In some edge cases this can lead to Kusto parsing failure, e.g. if the field name is a reserved word like 'datetime'.

The following changes are proposed:

* wrap the field name and fix all related tests
