### PR TITLE
Support unsorted terms

### DIFF
--- a/K2Bridge.Tests.UnitTests/Visitors/TermsVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/TermsVisitorTests.cs
@@ -12,6 +12,23 @@ namespace UnitTests.K2Bridge.Visitors
     [TestFixture]
     public class TermsVisitorTests
     {
+        [TestCase(ExpectedResult = "_data | summarize metric by ['key'] = ['field']\n| limit 10")]
+        public string TermsVisit_WithNullOrder_ReturnsValidResponse()
+        {
+            var termsAggregation = new TermsAggregation() {
+                Field = "field",
+                Key = "key",
+                Size = 10,
+                Order = null,
+                Metric = "metric",
+            };
+
+            var visitor = new ElasticSearchDSLVisitor(SchemaRetrieverMock.CreateMockSchemaRetriever());
+            visitor.Visit(termsAggregation);
+
+            return termsAggregation.KustoQL;
+        }
+
         [TestCase("_count", ExpectedResult = "_data | summarize metric by ['key'] = ['field']\n| order by count_ desc\n| limit 10", TestName = "TermsVisit_WithAggregationSortCount_ReturnsValidResponse")]
         [TestCase("_key", ExpectedResult = "_data | summarize metric by ['key'] = ['field']\n| order by ['key'] desc\n| limit 10", TestName = "TermsVisit_WithAggregationKeyCount_ReturnsValidResponse")]
         [TestCase("1", ExpectedResult = "_data | summarize metric by ['key'] = ['field']\n| order by ['1'] desc\n| limit 10", TestName = "TermsVisit_WithAggregationCustomCount_ReturnsValidResponse")]

--- a/K2Bridge/Models/Request/Aggregations/Bucket/Terms/TermsAggregation.cs
+++ b/K2Bridge/Models/Request/Aggregations/Bucket/Terms/TermsAggregation.cs
@@ -10,7 +10,7 @@ namespace K2Bridge.Models.Request.Aggregations
 
     /// <summary>
     /// Bucket aggregation that creates one bucket per unique value in the designated field.
-    // Default values are taken from Elasticserch API documentation.
+    /// Default values are taken from Elasticserch API documentation.
     /// </summary>
     internal class TermsAggregation : BucketAggregation
     {
@@ -20,6 +20,9 @@ namespace K2Bridge.Models.Request.Aggregations
         [JsonProperty("field")]
         public string Field { get; set; }
 
+        /// <summary>
+        /// Gets or sets the order of the results.
+        /// </summary>
         [JsonProperty("order")]
         [JsonConverter(typeof(TermsOrderConverter))]
         public TermsOrder Order { get; set; }

--- a/K2Bridge/Visitors/TermsVisitor.cs
+++ b/K2Bridge/Visitors/TermsVisitor.cs
@@ -21,21 +21,12 @@ namespace K2Bridge.Visitors
 
             termsAggregation.KustoQL = $"_data | {KustoQLOperators.Summarize} " + termsAggregation.SubAggregationsKustoQL + $"{termsAggregation.Metric} by {EncodeKustoField(termsAggregation.Key)} = {EncodeKustoField(termsAggregation.Field, true)}";
 
-            if (termsAggregation.Order.SortField == "_key")
-            {
-                // Alphabetical order
-                termsAggregation.KustoQL += $"{KustoQLOperators.CommandSeparator}{KustoQLOperators.OrderBy} {EncodeKustoField(termsAggregation.Key)} {termsAggregation.Order.SortOrder}";
-            }
-            else if (termsAggregation.Order.SortField == "_count")
-            {
-                // Count order
-                termsAggregation.KustoQL += $"{KustoQLOperators.CommandSeparator}{KustoQLOperators.OrderBy} {BucketColumnNames.Count} {termsAggregation.Order.SortOrder}";
-            }
-            else
-            {
-                // Custom order
-                termsAggregation.KustoQL += $"{KustoQLOperators.CommandSeparator}{KustoQLOperators.OrderBy} {EncodeKustoField(termsAggregation.Order.SortField)} {termsAggregation.Order.SortOrder}";
-            }
+            termsAggregation.KustoQL += termsAggregation.Order?.SortField switch {
+                "_key" => $"{KustoQLOperators.CommandSeparator}{KustoQLOperators.OrderBy} {EncodeKustoField(termsAggregation.Key)} {termsAggregation.Order.SortOrder}",
+                "_count" => $"{KustoQLOperators.CommandSeparator}{KustoQLOperators.OrderBy} {BucketColumnNames.Count} {termsAggregation.Order.SortOrder}",
+                { } s => $"{KustoQLOperators.CommandSeparator}{KustoQLOperators.OrderBy} {EncodeKustoField(s)} {termsAggregation.Order.SortOrder}",
+                _ => string.Empty,
+            };
 
             termsAggregation.KustoQL += $"{KustoQLOperators.CommandSeparator}{KustoQLOperators.Limit} {termsAggregation.Size}";
         }


### PR DESCRIPTION
Support unsorted terms, such as when using the "edit filter" in discover