### PR TITLE
Fix - Return empty results set when invalid field is used

### DIFF
--- a/K2Bridge.Tests.End2End/ParallelApiTest.cs
+++ b/K2Bridge.Tests.End2End/ParallelApiTest.cs
@@ -33,6 +33,13 @@ namespace K2Bridge.Tests.End2End
 
         [Test]
         [Description("/_msearch Kibana aggregation query returning zero results")]
+        public void CompareElasticKusto_WhenMSearchContainsInvalidFieldNameZeroResults_ResponsesAreEquivalent()
+        {
+            ParallelQuery($"{FLIGHTSDIR}/MSearch_Text_Contains_Invalid_Field.json", minResults: 0);
+        }
+
+        [Test]
+        [Description("/_msearch Kibana aggregation query returning zero results")]
         public void CompareElasticKusto_WhenMSearchZeroResults_ResponsesAreEquivalent()
         {
             ParallelQuery($"{FLIGHTSDIR}/MSearch_ZeroResults_Equivalent.json", minResults: 0);

--- a/K2Bridge.Tests.End2End/flights/MSearch_Text_Contains_Invalid_Field.json
+++ b/K2Bridge.Tests.End2End/flights/MSearch_Text_Contains_Invalid_Field.json
@@ -1,0 +1,80 @@
+{
+  "version": true,
+  "size": 500,
+  "sort": [
+    {
+      "timestamp": {
+        "order": "desc",
+        "unmapped_type": "boolean"
+      }
+    }
+  ],
+  "aggs": {
+    "2": {
+      "date_histogram": {
+        "field": "timestamp",
+        "calendar_interval": "month",
+        "time_zone": "UTC",
+        "min_doc_count": 1
+      }
+    }
+  },
+  "stored_fields": [
+    "*"
+  ],
+  "script_fields": {
+    "hour_of_day": {
+      "script": {
+        "source": "doc['timestamp'].value.hourOfDay",
+        "lang": "painless"
+      }
+    }
+  },
+  "docvalue_fields": [
+    {
+      "field": "timestamp",
+      "format": "date_time"
+    }
+  ],
+  "_source": {
+    "excludes": []
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "query_string": {
+            "query": "NotARealField:International",
+            "analyze_wildcard": true,
+            "time_zone": "UTC"
+          }
+        }
+      ],
+      "filter": [
+        {
+          "range": {
+            "timestamp": {
+              "gte": 1518000000000,
+              "lte": 1518005000000,
+              "format": "epoch_millis"
+            }
+          }
+        }
+      ],
+      "should": [],
+      "must_not": []
+    }
+  },
+  "highlight": {
+    "pre_tags": [
+      "@kibana-highlighted-field@"
+    ],
+    "post_tags": [
+      "@/kibana-highlighted-field@"
+    ],
+    "fields": {
+      "*": {}
+    },
+    "fragment_size": 2147483647
+  }
+}

--- a/K2Bridge/Controllers/ControllerExtractMethods.cs
+++ b/K2Bridge/Controllers/ControllerExtractMethods.cs
@@ -48,7 +48,7 @@ namespace K2Bridge.Controllers
         /// containing :. and replaces it, with a valid token.
         /// </summary>
         /// <param name="templateString">string to replace tokens in.</param>
-        /// <returns>string with charachter replaced back.</returns>
+        /// <returns>string with character replaced back.</returns>
         internal static string ReplaceBackTemplateString(string templateString) =>
             !string.IsNullOrEmpty(templateString) && templateString.Contains(TemplateString, StringComparison.OrdinalIgnoreCase) ?
                 templateString.Replace(AltTemplateQueryStringSeparator, TemplateQueryStringSeparator, StringComparison.OrdinalIgnoreCase) :

--- a/K2Bridge/Factories/BucketFactory.cs
+++ b/K2Bridge/Factories/BucketFactory.cs
@@ -120,7 +120,7 @@ namespace K2Bridge.Factories
             return rb;
         }
 
-        public static void CreateAggregationColumns(Bucket bucket, DataRow row, ILogger logger)
+        private static void CreateAggregationColumns(Bucket bucket, DataRow row, ILogger logger)
         {
             // TODO: refactor the columns handling based on the Percentiles code.
             // See: workitem 15724

--- a/K2Bridge/K2Bridge.csproj
+++ b/K2Bridge/K2Bridge.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />


### PR DESCRIPTION
The following changes are proposed:

* Instead of 500 Internal server error, return empty results set when invalid field is used
