### PR TITLE
Normalize Match All

### DIFF
--- a/K2Bridge.Tests.UnitTests/Visitors/LuceneNet/LuceneMatchAllDocsVisitorTests.cs
+++ b/K2Bridge.Tests.UnitTests/Visitors/LuceneNet/LuceneMatchAllDocsVisitorTests.cs
@@ -36,7 +36,7 @@ namespace UnitTests.K2Bridge.Visitors.LuceneNet
                 Throws.TypeOf<IllegalClauseException>());
         }
 
-        [TestCase(ExpectedResult = null)]
+        [TestCase(ExpectedResult = "true")]
         public string Visit_WithValidQuery_ReturnsValidResponse()
         {
             var query = new LuceneMatchAllDocsQuery

--- a/K2Bridge/Visitors/QueryStringClauseVisitor.cs
+++ b/K2Bridge/Visitors/QueryStringClauseVisitor.cs
@@ -84,7 +84,7 @@ namespace K2Bridge.Visitors
                     queryStringClause.KustoQL = $"{queryStringClause.ParsedFieldName} {KustoQLOperators.HasPrefix} \"{queryStringClause.Phrase.EscapeSlashes()}\"";
                     break;
                 case QueryStringClause.Subtype.MatchAll:
-                    // Match all returns everything, so we don't need a query
+                    queryStringClause.KustoQL = "true";
                     break;
                 default:
                     // should not happen


### PR DESCRIPTION
Change Matchall to return "true" instead of null, so it would work with complex kusto expressions.