### PR TITLE
Fixed client secret passing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,7 @@ stages:
           # Push Docker image
           docker push "$ACR_NAME.azurecr.io/k2bridge:$SEMANTIC_VERSION"
           docker push "$ACR_NAME.azurecr.io/k2bridge-test:$SEMANTIC_VERSION"
-          
+
   - job: push_helm_charts
     displayName: Prepare and push helm charts
     steps:
@@ -215,13 +215,13 @@ stages:
 
     - bash: |
         set -eu
-        az login --service-principal --username $(AKS_SP_CLIENT_ID) --password "$password" --tenant $(TENANT_ID)
+        az login --service-principal --username $(AKS_SP_CLIENT_ID) --password $PASS --tenant $(TENANT_ID)
         az aks get-versions --location westeurope
         oid=$(az ad sp show --id  $(AKS_SP_CLIENT_ID) --query objectId -o tsv)
         echo "##vso[task.setvariable variable=AKS_SP_OBJECT_ID]$oid"
       displayName: Get AKS SP object ID
       env:
-        password: $(AKS_SP_CLIENT_SECRET)
+        PASS: $(AKS_SP_CLIENT_SECRET)
 
     - template: infrastructure/terraform-tasks-template.yml
       parameters:


### PR DESCRIPTION
Fixed client secret passing in the yml.

Turns out the quotes were parsed literally and made the password be wrong.
Since azure secrets don't have spaces or special bash characters, this is fine (and works in practice)